### PR TITLE
Add RPM packaging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,48 @@ build-amd64-ubuntu-disco:
   only:
     - tags
 
+build-amd64-fedora-29:
+  stage: build
+  image: fedora:29
+  script:
+    - ./gitlab-build-rpm.sh fedora29
+    - mkdir -p built-packages/fedora_29/
+    - mv ~/rpmbuild/RPMS/x86_64/*.rpm built-packages/fedora_29/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
+build-amd64-fedora-30:
+  stage: build
+  image: fedora:30
+  script:
+    - ./gitlab-build-rpm.sh fedora30
+    - mkdir -p built-packages/fedora_30/
+    - mv ~/rpmbuild/RPMS/x86_64/*.rpm built-packages/fedora_30/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
+build-amd64-centos7:
+  stage: build
+  image: centos:7
+  script:
+    - ./gitlab-build-rpm.sh centos7
+    - mkdir -p built-packages/centos_7/
+    - mv ~/rpmbuild/RPMS/x86_64/*.rpm built-packages/centos_7/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
 upload-packages:
   stage: upload
   image: ubuntu:bionic

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,6 +72,20 @@ build-amd64-ubuntu-cosmic:
   only:
     - tags
 
+build-amd64-ubuntu-disco:
+  stage: build
+  image: ubuntu:disco
+  script:
+    - ./gitlab-build.sh
+    - mkdir -p built-packages/disco/
+    - mv ../*.deb built-packages/disco/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
 upload-packages:
   stage: upload
   image: ubuntu:bionic

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,11 +3,12 @@ EXTRA_DIST=doc README.md
 
 AUTOMAKE_OPTIONS=foreign
 
-dist_sysconf_DATA=doc/exampleconfigs/collector-example.yaml \
+openliconfdir=$(sysconfdir)/openli
+dist_openliconf_DATA=doc/exampleconfigs/collector-example.yaml \
         doc/exampleconfigs/mediator-example.yaml \
         doc/exampleconfigs/provisioner-example.yaml
 
-syslogdir=$(pkgdatadir)/rsyslog
+syslogdir=$(sysconfdir)/rsyslog.d/
 dist_syslog_DATA=rsyslog/*
 
 dist_doc_DATA=doc/CollectorDoc.md doc/MediatorDoc.md doc/ProvisionerDoc.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,8 @@
+DISTCHECK_CONFIGURE_FLAGS = \
+        --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
+
 SUBDIRS=extlib src
-EXTRA_DIST=doc README.md
+EXTRA_DIST=doc README.md systemd/*.service
 
 AUTOMAKE_OPTIONS=foreign
 
@@ -15,3 +18,19 @@ dist_doc_DATA=doc/CollectorDoc.md doc/MediatorDoc.md doc/ProvisionerDoc.md
 
 mandir=$(pkgdatadir)/doc/man
 
+if HAVE_SYSTEMD
+systemdsystemunit_DATA =
+
+if BUILD_COLLECTOR
+systemdsystemunit_DATA += systemd/openli-collector.service
+endif
+
+if BUILD_PROVISIONER
+systemdsystemunit_DATA += systemd/openli-provisioner.service
+endif
+
+if BUILD_MEDIATOR
+systemdsystemunit_DATA += systemd/openli-mediator.service
+endif
+
+endif

--- a/bintray-upload.sh
+++ b/bintray-upload.sh
@@ -2,7 +2,8 @@
 
 set -e -o pipefail
 
-BINTRAY_REPO="wand/OpenLI"
+BINTRAY_DEB_REPO="wand/OpenLI"
+BINTRAY_RPM_REPO="wand/OpenLI-rpm"
 BINTRAY_LICENSE="GPL-3.0"
 
 apt-get update && apt-get install -y curl
@@ -26,10 +27,37 @@ EOF
 for path in `find built-packages/ -maxdepth 1 -type d`; do
     IFS=_ read linux_version <<< $(basename "${path}")
     for deb in `find "${path}" -maxdepth 1 -type f`; do
+        ext=${deb##*.}
         pkg_filename=$(basename "${deb}")
-        IFS=_ read pkg_name pkg_version pkg_arch <<< $(basename -s ".deb" "${pkg_filename}")
-        jfrog bt package-create --licenses ${BINTRAY_LICENSE} --vcs-url ${CI_PROJECT_URL} ${BINTRAY_REPO}/${pkg_name} || true
-        jfrog bt upload --deb ${linux_version}/main/${pkg_arch} ${deb} ${BINTRAY_REPO}/${pkg_name}/${pkg_version} pool/${linux_version}/main/${pkg_name}/
+
+        if [ "$ext" = "deb" ]; then
+            IFS=_ read pkg_name pkg_version pkg_arch <<< $(basename -s ".deb" "${pkg_filename}")
+            jfrog bt package-create --licenses ${BINTRAY_LICENSE} --vcs-url ${CI_PROJECT_URL} ${BINTRAY_DEB_REPO}/${pkg_name} || true
+            jfrog bt upload --deb ${linux_version}/main/${pkg_arch} ${deb} ${BINTRAY_DEB_REPO}/${pkg_name}/${pkg_version} pool/${linux_version}/main/${pkg_name}/
+        fi
+
+        if [ "$ext" = "rpm" ]; then
+            rev_filename=`echo ${pkg_filename} | rev`
+
+            if [[ ${linux_version} =~ centos_* ]]; then
+                # centos
+                pkg_dist="centos"
+
+            else
+                # fedora
+                pkg_dist="fedora"
+            fi
+
+            pkg_name=`echo ${rev_filename} | cut -d '-' -f3- | rev`
+            pkg_version=`echo ${rev_filename} | cut -d '-' -f1-2 | rev | cut -d '.' -f1-3`
+            pkg_arch=`echo ${rev_filename} | cut -d '.' -f2 | rev`
+            pkg_rel=`echo ${rev_filename} | cut -d '.' -f3 | rev`
+            releasever="${pkg_rel:2}"
+
+
+            jfrog bt package-create --licenses ${BINTRAY_LICENSE} --vcs-url ${CI_PROJECT_URL} ${BINTRAY_RPM_REPO}/${pkg_name} || true
+            jfrog bt upload ${deb} ${BINTRAY_RPM_REPO}/${pkg_name}/${pkg_version} ${pkg_dist}/${releasever}/${pkg_arch}/
+
+        fi
     done
 done
-

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,13 @@ AC_ARG_ENABLE([provisioner], AS_HELP_STRING([--disable-provisioner],
 AC_ARG_ENABLE([collector], AS_HELP_STRING([--disable-collector],
         [Disable building the OpenLI collector]))
 
+PKG_PROG_PKG_CONFIG
+AC_ARG_WITH([systemdsystemunitdir],
+        AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
+                [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
+AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir"])
+
 PROVISIONER_LIBS=
 COLLECTOR_LIBS=
 MEDIATOR_LIBS=

--- a/debian/openli-collector.install
+++ b/debian/openli-collector.install
@@ -1,4 +1,4 @@
 usr/bin/openlicollector
 etc/openli/collector*
-usr/share/openli/rsyslog/10-openli-collector.conf etc/rsyslog.d
+etc/rsyslog.d/10-openli-collector.conf
 usr/share/doc/openli/CollectorDoc.md

--- a/debian/openli-mediator.install
+++ b/debian/openli-mediator.install
@@ -1,4 +1,4 @@
 usr/bin/openlimediator
 etc/openli/mediator*
-usr/share/openli/rsyslog/10-openli-mediator.conf etc/rsyslog.d
+etc/rsyslog.d/10-openli-mediator.conf
 usr/share/doc/openli/MediatorDoc.md

--- a/debian/openli-provisioner.install
+++ b/debian/openli-provisioner.install
@@ -1,4 +1,4 @@
 usr/bin/openliprovisioner
 etc/openli/provisioner*
-usr/share/openli/rsyslog/10-openli-provisioner.conf etc/rsyslog.d
+etc/rsyslog.d/10-openli-provisioner.conf
 usr/share/doc/openli/ProvisionerDoc.md

--- a/debian/rules
+++ b/debian/rules
@@ -13,9 +13,6 @@ override_dh_install:
 override_dh_auto_install:
 	$(MAKE) DESTDIR=$$(pwd)/debian/openli prefix=/usr install
 
-override_dh_systemd_enable:
-	dh_systemd_enable --no-enable
-
 override_dh_installinit:
 	dh_installinit --no-start
 

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@
 
 
 override_dh_auto_configure:
-	dh_auto_configure -- --sysconfdir=/etc/openli
+	dh_auto_configure -- --sysconfdir=/etc/
 
 override_dh_install:
 	dh_install --sourcedir=debian/openli

--- a/gitlab-build-rpm.sh
+++ b/gitlab-build-rpm.sh
@@ -43,6 +43,7 @@ yum install -y wget make gcc
 
 if [ "$1" = "centos7" ]; then
         yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true
+        yum install -y http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm || true
 fi
 
 if [ "$1" = "centos6" ]; then

--- a/gitlab-build-rpm.sh
+++ b/gitlab-build-rpm.sh
@@ -1,0 +1,71 @@
+set -x -e -o pipefail
+
+if [ "${CI_COMMIT_REF_NAME}" = "" ]; then
+        CI_COMMIT_REF_NAME=1.0.2
+fi
+
+export QA_RPATHS=$[ 0x0001 ]
+SOURCENAME=`echo ${CI_COMMIT_REF_NAME} | cut -d '-' -f 1`
+
+
+DISTRO=fedora
+if [ "$1" = "centos7" ]; then
+        DISTRO=centos
+fi
+
+if [ "$1" = "centos6" ]; then
+        DISTRO=centos
+fi
+
+cat << EOF > /etc/yum.repos.d/bintray-wand-general-rpm.repo
+#bintray-wand-general-rpm - packages by wand from Bintray
+[bintray-wand-general-rpm]
+name=bintray-wand-general-rpm
+baseurl=https://dl.bintray.com/wand/general-rpm/${DISTRO}/\$releasever/\$basearch/
+gpgkey=https://bintray.com/user/downloadSubjectPublicKey?username=wand
+gpgcheck=0
+repo_gpgcheck=1
+enabled=1
+EOF
+
+cat << EOF > /etc/yum.repos.d/bintray-wand-libtrace-rpm.repo
+#bintray-wand-libtrace-rpm - packages by wand from Bintray
+[bintray-wand-libtrace-rpm]
+name=bintray-wand-libtrace-rpm
+baseurl=https://dl.bintray.com/wand/libtrace-rpm/${DISTRO}/\$releasever/\$basearch/
+gpgkey=https://bintray.com/user/downloadSubjectPublicKey?username=wand
+gpgcheck=0
+repo_gpgcheck=1
+enabled=1
+EOF
+
+yum install -y wget make gcc
+
+if [ "$1" = "centos7" ]; then
+        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true
+fi
+
+if [ "$1" = "centos6" ]; then
+        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm || true
+        yum install -y epel-rpm-macros
+fi
+
+
+if [[ "$1" =~ fedora* ]]; then
+        dnf install -y rpm-build rpmdevtools 'dnf-command(builddep)' which
+        dnf group install -y "C Development Tools and Libraries"
+        dnf builddep -y rpm/openli.spec
+else
+        yum install -y rpm-build yum-utils rpmdevtools which
+        yum groupinstall -y 'Development Tools'
+        yum-builddep -y rpm/openli.spec
+fi
+
+rpmdev-setuptree
+
+./bootstrap.sh && ./configure && make dist
+cp openli-*.tar.gz ~/rpmbuild/SOURCES/${SOURCENAME}.tar.gz
+cp rpm/openli.spec ~/rpmbuild/SPECS/
+
+cd ~/rpmbuild && rpmbuild -bb --define "debug_package %{nil}" SPECS/openli.spec
+

--- a/gitlab-build.sh
+++ b/gitlab-build.sh
@@ -6,6 +6,8 @@ export DEBEMAIL='packaging@wand.net.nz'
 export DEBFULLNAME='WAND Packaging'
 export DEBIAN_FRONTEND=noninteractive
 
+SOURCENAME=`echo ${CI_COMMIT_REF_NAME} | cut -d '-' -f 1`
+
 apt-get update
 apt-get install -y equivs devscripts dpkg-dev quilt curl apt-transport-https \
     apt-utils ssl-cert ca-certificates gnupg lsb-release debhelper git
@@ -21,6 +23,6 @@ curl --silent "https://bintray.com/user/downloadSubjectPublicKey?username=wand"\
 apt-get update
 apt-get upgrade -y
 
-dpkg-parsechangelog -S version | grep -q ${CI_COMMIT_REF_NAME} || debchange --newversion ${CI_COMMIT_REF_NAME} -b "New upstream release"
+dpkg-parsechangelog -S version | grep -q ${SOURCENAME} || debchange --newversion ${SOURCENAME} -b "New upstream release"
 mk-build-deps -i -r -t 'apt-get -f -y --force-yes'
 dpkg-buildpackage -b -us -uc -rfakeroot -j4

--- a/rpm/openli.spec
+++ b/rpm/openli.spec
@@ -1,0 +1,172 @@
+Name:           openli
+Version:        1.0.2
+Release:        1%{?dist}
+Summary:        Software for performing ETSI-compliant lawful intercept
+
+License:        GPLv3
+URL:            https://github.com/wanduow/OpenLI
+Source0:        https://github.com/wanduow/OpenLI/archive/%{version}.tar.gz
+
+BuildRequires: gcc
+BuildRequires: gcc-c++
+BuildRequires: make
+BuildRequires: bison
+BuildRequires: doxygen
+BuildRequires: flex
+BuildRequires: libyaml-devel
+BuildRequires: libtrace4-devel
+BuildRequires: Judy-devel
+BuildRequires: uthash-devel
+BuildRequires: libwandder1-devel
+BuildRequires: zeromq-devel
+BuildRequires: gperftools-devel
+BuildRequires: libosip2-devel
+BuildRequires: systemd
+
+%description
+Software for performing ETSI-compliant lawful intercept
+
+%package        provisioner
+Summary:        Central provisioning daemon for an OpenLI system
+
+%description provisioner
+OpenLI is a software suite that allows network operators to conduct
+lawful interception of Internet traffic that is compliant with the
+ETSI Lawful Intercept standards.
+This package contains the provisioner component of the OpenLI
+lawful intercept software. The provisioner acts as a centralised
+controller for the deployed OpenLI collectors and mediators.
+Intercepts are configured on the provisioner, which then pushes
+the necessary intercept instructions to any registered collectors
+and mediators.
+
+%package        mediator
+Summary:        Mediation daemon for an OpenLI system
+
+%description mediator
+OpenLI is a software suite that allows network operators to conduct
+lawful interception of Internet traffic that is compliant with the
+ETSI Lawful Intercept standards.
+This package contains the mediator component of the OpenLI
+lawful intercept software. The mediator collates intercepted
+(and encoded) packets from the collectors and routes the packets
+to the appropriate law enforcement agency (LEA). The mediator will
+maintain active TCP sessions to all known LEAs for both handover
+interface 2 and 3, using keep-alives as per the ETSI standard.
+
+%package        collector
+Summary:        Collector daemon for an OpenLI system
+
+%description collector
+OpenLI is a software suite that allows network operators to conduct
+lawful interception of Internet traffic that is compliant with the
+ETSI Lawful Intercept standards.
+This package contains the collector component of the OpenLI lawful
+intercept software. The collector captures packets on one or more
+specified network interfaces, identifies traffic that should be
+intercepted (based on instructions from an OpenLI provisioner),
+encodes the intercepted traffic using the format described in the
+ETSI specifications, and forwards the encoded traffic to the
+appropriate mediator for export to the law enforcement agency that
+requested the intercept.
+
+
+
+%prep
+%setup -q -n openli-%{version}
+
+%build
+%configure --disable-static --with-man=yes --mandir=%{_mandir} --sysconfdir=/etc/
+make %{?_smp_mflags}
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%make_install
+find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
+
+%post provisioner
+if [ $1 -eq 1 ]; then
+        /bin/systemctl enable openli-provisioner.service openli-provisioner.socket >/dev/null 2>&1 || :
+fi
+
+%preun provisioner
+if [ $1 -eq 0 ]; then
+        # Disable and stop the units
+        /bin/systemctl disable openli-provisioner.service openli-provisioner.socket >/dev/null 2>&1 || :
+        /bin/systemctl stop openli-provisioner.service openli-provisioner.socket >/dev/null 2>&1 || :
+fi
+
+%postun provisioner
+if [ $1 -ge 1 ]; then
+        # On upgrade, reload init system configuration if we changed unit files
+        /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+        # On upgrade, restart the daemon
+        /bin/systemctl try-restart openli-provisioner.service >/dev/null 2>&1 || :
+fi
+
+%post mediator
+if [ $1 -eq 1 ]; then
+        /bin/systemctl enable openli-mediator.service openli-mediator.socket >/dev/null 2>&1 || :
+fi
+
+%preun mediator
+if [ $1 -eq 0 ]; then
+        # Disable and stop the units
+        /bin/systemctl disable openli-mediator.service openli-mediator.socket >/dev/null 2>&1 || :
+        /bin/systemctl stop openli-mediator.service openli-mediator.socket >/dev/null 2>&1 || :
+fi
+
+%postun mediator
+if [ $1 -ge 1 ]; then
+        # On upgrade, reload init system configuration if we changed unit files
+        /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+        # On upgrade, restart the daemon
+        /bin/systemctl try-restart openli-mediator.service >/dev/null 2>&1 || :
+fi
+
+%post collector
+if [ $1 -eq 1 ]; then
+        /bin/systemctl enable openli-collector.service openli-collector.socket >/dev/null 2>&1 || :
+fi
+
+%preun collector
+if [ $1 -eq 0 ]; then
+        # Disable and stop the units
+        /bin/systemctl disable openli-collector.service openli-collector.socket >/dev/null 2>&1 || :
+        /bin/systemctl stop openli-collector.service openli-collector.socket >/dev/null 2>&1 || :
+fi
+
+%postun collector
+if [ $1 -ge 1 ]; then
+        # On upgrade, reload init system configuration if we changed unit files
+        /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+        # On upgrade, restart the daemon
+        /bin/systemctl try-restart openli-collector.service >/dev/null 2>&1 || :
+fi
+
+%files provisioner
+%{_bindir}/openliprovisioner
+%{_unitdir}/openli-provisioner.service
+%config %{_sysconfdir}/rsyslog.d/10-openli-provisioner.conf
+%config %{_sysconfdir}/openli/provisioner-example.yaml
+%doc %{_docdir}/openli/ProvisionerDoc.md
+
+%files mediator
+%{_bindir}/openlimediator
+%{_unitdir}/openli-mediator.service
+%config %{_sysconfdir}/rsyslog.d/10-openli-mediator.conf
+%config %{_sysconfdir}/openli/mediator-example.yaml
+%doc %{_docdir}/openli/MediatorDoc.md
+
+%files collector
+%{_bindir}/openlicollector
+%{_unitdir}/openli-collector.service
+%config %{_sysconfdir}/rsyslog.d/10-openli-collector.conf
+%config %{_sysconfdir}/openli/collector-example.yaml
+%doc %{_docdir}/openli/CollectorDoc.md
+
+
+%changelog
+* Tue Jun 4 2019 Shane Alcock <salcock@waikato.ac.nz> - 1.0.2-1
+- First OpenLI RPM package

--- a/systemd/openli-collector.service
+++ b/systemd/openli-collector.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenLI collector daemon
+Documentation=http://github.com/wanduow/openli/wiki
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/openlicollector -c /etc/openli/collector-config.yaml
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/openli-mediator.service
+++ b/systemd/openli-mediator.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenLI mediator daemon
+Documentation=http://github.com/wanduow/openli/wiki
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/openlimediator -c /etc/openli/mediator-config.yaml
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/openli-provisioner.service
+++ b/systemd/openli-provisioner.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenLI provisioner daemon
+Documentation=http://github.com/wanduow/openli/wiki
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/openliprovisioner -c /etc/openli/provisioner-config.yaml
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Can now build and upload RPMs for Fedora and Centos 7.

Other packaging changes:
 * Add systemd unit files for each component, which will replace the old init scripts.
 * Update packaging scripts to build packages for Ubuntu Disco
 * Install syslog config into /etc/rsyslog.d directly when doing a `make install`