### PR TITLE
Add ability to encrypt internal communications with TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ ltmain.sh
 missing
 stamp-h1
 m4/*.m4
+#added for dev
+.vscode/*
+*.dirstamp
+dockertests/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,48 @@ build-amd64-ubuntu-disco:
   only:
     - tags
 
+build-amd64-fedora-29:
+  stage: build
+  image: fedora:29
+  script:
+    - ./gitlab-build-rpm.sh fedora29
+    - mkdir -p built-packages/fedora_29/
+    - mv ~/rpmbuild/RPMS/x86_64/*.rpm built-packages/fedora_29/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
+build-amd64-fedora-30:
+  stage: build
+  image: fedora:30
+  script:
+    - ./gitlab-build-rpm.sh fedora30
+    - mkdir -p built-packages/fedora_30/
+    - mv ~/rpmbuild/RPMS/x86_64/*.rpm built-packages/fedora_30/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
+build-amd64-centos7:
+  stage: build
+  image: centos:7
+  script:
+    - ./gitlab-build-rpm.sh centos7
+    - mkdir -p built-packages/centos_7/
+    - mv ~/rpmbuild/RPMS/x86_64/*.rpm built-packages/centos_7/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
 upload-packages:
   stage: upload
   image: ubuntu:bionic

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,6 +72,20 @@ build-amd64-ubuntu-cosmic:
   only:
     - tags
 
+build-amd64-ubuntu-disco:
+  stage: build
+  image: ubuntu:disco
+  script:
+    - ./gitlab-build.sh
+    - mkdir -p built-packages/disco/
+    - mv ../*.deb built-packages/disco/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
 upload-packages:
   stage: upload
   image: ubuntu:bionic

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,21 @@
+The original OpenLI implementation was written by Shane Alcock, while
+working for the WAND network research group at the University of Waikato.
+
+The current lead developer and maintainer of OpenLI is Shane Alcock (still!).
+Email: salcock@waikato.ac.nz
+
+------
+
+OpenLI is an open source project which was developed for public good. We
+welcome contributions from our users and friendly programmers and have
+dedicated this AUTHORS file to acknowledging the efforts of those who have
+contributed something back to the OpenLI project already.
+
+In no particular order, we would like to thank the following people:
+
+ * Tyler Marriner for adding support for encrypting inter-component
+   communications using TLS.
+
+Apologies to anyone that has made a contribution but we've forgotten to
+mention you here -- if this has happened to you, please get in touch with the
+project maintainer and let them know about the oversight.

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,11 +3,12 @@ EXTRA_DIST=doc README.md
 
 AUTOMAKE_OPTIONS=foreign
 
-dist_sysconf_DATA=doc/exampleconfigs/collector-example.yaml \
+openliconfdir=$(sysconfdir)/openli
+dist_openliconf_DATA=doc/exampleconfigs/collector-example.yaml \
         doc/exampleconfigs/mediator-example.yaml \
         doc/exampleconfigs/provisioner-example.yaml
 
-syslogdir=$(pkgdatadir)/rsyslog
+syslogdir=$(sysconfdir)/rsyslog.d/
 dist_syslog_DATA=rsyslog/*
 
 dist_doc_DATA=doc/CollectorDoc.md doc/MediatorDoc.md doc/ProvisionerDoc.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,8 @@
+DISTCHECK_CONFIGURE_FLAGS = \
+        --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
+
 SUBDIRS=extlib src
-EXTRA_DIST=doc README.md
+EXTRA_DIST=doc README.md systemd/*.service
 
 AUTOMAKE_OPTIONS=foreign
 
@@ -15,3 +18,19 @@ dist_doc_DATA=doc/CollectorDoc.md doc/MediatorDoc.md doc/ProvisionerDoc.md
 
 mandir=$(pkgdatadir)/doc/man
 
+if HAVE_SYSTEMD
+systemdsystemunit_DATA =
+
+if BUILD_COLLECTOR
+systemdsystemunit_DATA += systemd/openli-collector.service
+endif
+
+if BUILD_PROVISIONER
+systemdsystemunit_DATA += systemd/openli-provisioner.service
+endif
+
+if BUILD_MEDIATOR
+systemdsystemunit_DATA += systemd/openli-mediator.service
+endif
+
+endif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 OpenLI -- open source ETSI-compliant Lawful Intercept software
 
-Version: 1.0.2
+Version: 1.0.3
 
 ---------------------------------------------------------------------------
 

--- a/bintray-upload.sh
+++ b/bintray-upload.sh
@@ -2,7 +2,8 @@
 
 set -e -o pipefail
 
-BINTRAY_REPO="wand/OpenLI"
+BINTRAY_DEB_REPO="wand/OpenLI"
+BINTRAY_RPM_REPO="wand/OpenLI-rpm"
 BINTRAY_LICENSE="GPL-3.0"
 
 apt-get update && apt-get install -y curl
@@ -26,10 +27,37 @@ EOF
 for path in `find built-packages/ -maxdepth 1 -type d`; do
     IFS=_ read linux_version <<< $(basename "${path}")
     for deb in `find "${path}" -maxdepth 1 -type f`; do
+        ext=${deb##*.}
         pkg_filename=$(basename "${deb}")
-        IFS=_ read pkg_name pkg_version pkg_arch <<< $(basename -s ".deb" "${pkg_filename}")
-        jfrog bt package-create --licenses ${BINTRAY_LICENSE} --vcs-url ${CI_PROJECT_URL} ${BINTRAY_REPO}/${pkg_name} || true
-        jfrog bt upload --deb ${linux_version}/main/${pkg_arch} ${deb} ${BINTRAY_REPO}/${pkg_name}/${pkg_version} pool/${linux_version}/main/${pkg_name}/
+
+        if [ "$ext" = "deb" ]; then
+            IFS=_ read pkg_name pkg_version pkg_arch <<< $(basename -s ".deb" "${pkg_filename}")
+            jfrog bt package-create --licenses ${BINTRAY_LICENSE} --vcs-url ${CI_PROJECT_URL} ${BINTRAY_DEB_REPO}/${pkg_name} || true
+            jfrog bt upload --deb ${linux_version}/main/${pkg_arch} ${deb} ${BINTRAY_DEB_REPO}/${pkg_name}/${pkg_version} pool/${linux_version}/main/${pkg_name}/
+        fi
+
+        if [ "$ext" = "rpm" ]; then
+            rev_filename=`echo ${pkg_filename} | rev`
+
+            if [[ ${linux_version} =~ centos_* ]]; then
+                # centos
+                pkg_dist="centos"
+
+            else
+                # fedora
+                pkg_dist="fedora"
+            fi
+
+            pkg_name=`echo ${rev_filename} | cut -d '-' -f3- | rev`
+            pkg_version=`echo ${rev_filename} | cut -d '-' -f1-2 | rev | cut -d '.' -f1-3`
+            pkg_arch=`echo ${rev_filename} | cut -d '.' -f2 | rev`
+            pkg_rel=`echo ${rev_filename} | cut -d '.' -f3 | rev`
+            releasever="${pkg_rel:2}"
+
+
+            jfrog bt package-create --licenses ${BINTRAY_LICENSE} --vcs-url ${CI_PROJECT_URL} ${BINTRAY_RPM_REPO}/${pkg_name} || true
+            jfrog bt upload ${deb} ${BINTRAY_RPM_REPO}/${pkg_name}/${pkg_version} ${pkg_dist}/${releasever}/${pkg_arch}/
+
+        fi
     done
 done
-

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,13 @@ AC_ARG_ENABLE([provisioner], AS_HELP_STRING([--disable-provisioner],
 AC_ARG_ENABLE([collector], AS_HELP_STRING([--disable-collector],
         [Disable building the OpenLI collector]))
 
+PKG_PROG_PKG_CONFIG
+AC_ARG_WITH([systemdsystemunitdir],
+        AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
+                [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
+AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir"])
+
 PROVISIONER_LIBS=
 COLLECTOR_LIBS=
 MEDIATOR_LIBS=

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,10 @@ AC_CHECK_LIB([trace], [trace_increment_packet_refcount],,libtrace_found=0)
 AC_CHECK_LIB([yaml], [yaml_document_get_node],,libyaml_found=0)
 AC_CHECK_LIB([zmq], [zmq_poll],libzmq_found=1,libzmq_found=0)
 AC_CHECK_LIB([m], [pow],,libm_found=0)
+AC_CHECK_LIB([ssl], [SSL_library_init],libssl_found=1,)
+AC_CHECK_LIB([ssl], [OPENSSL_init_ssl],libssl_found=1,)
+AC_CHECK_LIB([crypto], [ERR_load_crypto_strings],libcrypto_found=1,)
+AC_CHECK_LIB([crypto], [EVP_CIPHER_CTX_new],libcrypto_found=1,)
 
 if test "x$libzmq_found" = "x1"; then
         COLLECTOR_LIBS="$COLLECTOR_LIBS -lzmq"
@@ -84,6 +88,22 @@ fi
 
 if test "$libtrace_found" = 0; then
         AC_MSG_ERROR(Required library libtrace 4.0.4 not found; use LDFLAGS to specify library location)
+fi
+
+if test "$libssl_found" != 1; then
+        AC_MSG_ERROR(Required library libssl not found; use LDFLAGS to specify library location)
+else
+        COLLECTOR_LIBS="$COLLECTOR_LIBS -lssl"
+        MEDIATOR_LIBS="$MEDIATOR_LIBS -lssl"
+        PROVISIONER_LIBS="$PROVISIONER_LIBS -lssl"
+fi
+
+if test "$libcrypto_found" != 1; then
+        AC_MSG_ERROR(Required library libcrypto not found; use LDFLAGS to specify library location)
+else
+        COLLECTOR_LIBS="$COLLECTOR_LIBS -lcrypto"
+        MEDIATOR_LIBS="$MEDIATOR_LIBS -lcrypto"
+        PROVISIONER_LIBS="$PROVISIONER_LIBS -lcrypto"
 fi
 
 if test "$libyaml_found" = 0; then

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Super primitive configure script
 
-AC_INIT(openli, 1.0.2, salcock@waikato.ac.nz)
+AC_INIT(openli, 1.0.3, salcock@waikato.ac.nz)
 
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR(src/collector/collector.c)

--- a/createCerts
+++ b/createCerts
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+openssl req -newkey rsa:4096 -nodes -sha512 -config sslgen.conf -x509 -days 3650 -nodes --subj /CN=OpenLItestCA -out ca-crt.pem -keyout ca-key.pem
+
+openssl genrsa -out provisioner-key.pem 4096
+openssl req -new -sha256 -config sslgen.conf -key provisioner-key.pem -out provisioner-csr.pem 
+openssl x509 -req -days 365 -in provisioner-csr.pem -CA ca-crt.pem  -CAkey ca-key.pem -CAcreateserial -out provisioner-crt.pem
+
+openssl genrsa -out mediator-key.pem 4096
+openssl req -new -sha256 -config sslgen.conf -key mediator-key.pem -out mediator-csr.pem
+openssl x509 -req -days 365 -in mediator-csr.pem -CA ca-crt.pem -CAkey ca-key.pem -CAcreateserial -out mediator-crt.pem
+
+openssl genrsa -out collector-key.pem 4096
+openssl req -new -sha256 -config sslgen.conf -key collector-key.pem -out collector-csr.pem
+openssl x509 -req -days 365 -in collector-csr.pem -CA ca-crt.pem -CAkey ca-key.pem -CAcreateserial -out collector-crt.pem
+
+
+#creates mediator-crt.pem  mediator-csr.pem  mediator-key.pem  provisioner-crt.pem  provisioner-csr.pem  provisioner-key.pem  ca-crt.pem  ca-key.pem

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+openli (1.0.3-1) UNRELEASED; urgency=medium
+
+  * Add ability to encrypt inter-component communications using TLS
+  * Add support for decapsulating JMirror captures
+  * Fix bug where ALU intercepts would erroneously intercept ARP packets
+
+ -- Shane Alcock <shane.alcock@waikato.ac.nz>  Tue, 25 Jun 2019 14:34:26 +1200
+
 openli (1.0.2-1) unstable; urgency=medium
 
   * Greatly improved RADIUS processing performance.

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,8 @@ Priority: optional
 Maintainer: Shane Alcock <shane.alcock@waikato.ac.nz>
 Build-Depends: debhelper (>= 9), dh-autoreconf, dh-systemd (>=1.5),
  libtrace4-dev, libyaml-dev, uthash-dev, libwandder1-dev, libjudy-dev,
- libzmq3-dev, libgoogle-perftools-dev, libosip2-dev
+ libzmq3-dev, libgoogle-perftools-dev, libosip2-dev,
+ libssl1.0-dev (>=1.0.2r) | libssl-dev
 Standards-Version: 4.1.3
 Homepage: https://openli.nz
 

--- a/debian/openli-collector.install
+++ b/debian/openli-collector.install
@@ -1,4 +1,4 @@
 usr/bin/openlicollector
 etc/openli/collector*
-usr/share/openli/rsyslog/10-openli-collector.conf etc/rsyslog.d
+etc/rsyslog.d/10-openli-collector.conf
 usr/share/doc/openli/CollectorDoc.md

--- a/debian/openli-mediator.install
+++ b/debian/openli-mediator.install
@@ -1,4 +1,4 @@
 usr/bin/openlimediator
 etc/openli/mediator*
-usr/share/openli/rsyslog/10-openli-mediator.conf etc/rsyslog.d
+etc/rsyslog.d/10-openli-mediator.conf
 usr/share/doc/openli/MediatorDoc.md

--- a/debian/openli-provisioner.install
+++ b/debian/openli-provisioner.install
@@ -1,4 +1,4 @@
 usr/bin/openliprovisioner
 etc/openli/provisioner*
-usr/share/openli/rsyslog/10-openli-provisioner.conf etc/rsyslog.d
+etc/rsyslog.d/10-openli-provisioner.conf
 usr/share/doc/openli/ProvisionerDoc.md

--- a/debian/rules
+++ b/debian/rules
@@ -13,9 +13,6 @@ override_dh_install:
 override_dh_auto_install:
 	$(MAKE) DESTDIR=$$(pwd)/debian/openli prefix=/usr install
 
-override_dh_systemd_enable:
-	dh_systemd_enable --no-enable
-
 override_dh_installinit:
 	dh_installinit --no-start
 

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@
 
 
 override_dh_auto_configure:
-	dh_auto_configure -- --sysconfdir=/etc/openli
+	dh_auto_configure -- --sysconfdir=/etc/
 
 override_dh_install:
 	dh_install --sourcedir=debian/openli

--- a/doc/exampleconfigs/collector-example.yaml
+++ b/doc/exampleconfigs/collector-example.yaml
@@ -4,6 +4,10 @@
 provisioneraddr: 10.0.0.1
 provisionerport: 9001
 
+tlscert: clientA-crt.pem
+tlskey: clientA-key.pem
+tlsca: ca-crt.pem
+
 # Unique ID string for my network (16 chars max)
 operatorid: WAND
 
@@ -37,9 +41,9 @@ logstatfrequency: 5
 #       intercept mirror, not the host that is doing the mirroring.
 # NOTE: ALU LI translation is a special case that won't apply to most users,
 #       but the configuration is included here for completeness
-alumirrors:
- - ip: 10.100.0.233
-   port: 8500
+#alumirrors:
+# - ip: 10.100.0.233
+#   port: 8500
 
 
 # List of Juniper mirrors that we are acting as a mediator for.
@@ -55,8 +59,8 @@ jmirrors:
 
 # List of interfaces to capture packets on
 inputs:
- - uri: eth1            # capture on interface eth1
+ - uri: lo            # capture on interface eth1
    threads: 2           # use 2 processing threads for this input
 
- - uri: dpdk:0000:42:00.0     # capture on DPDK interface with this PCI address
-   threads: 4                 # use 4 processing threads for this input
+# - uri: dpdk:0000:42:00.0     # capture on DPDK interface with this PCI address
+#   threads: 4                 # use 4 processing threads for this input

--- a/doc/exampleconfigs/mediator-example.yaml
+++ b/doc/exampleconfigs/mediator-example.yaml
@@ -10,6 +10,10 @@ mediatorid: 6001
 provisioneraddr: 10.0.0.1
 provisionerport: 12001
 
+tlscert: clientB-crt.pem
+tlskey: clientB-key.pem
+tlsca: ca-crt.pem
+
 # Listen for collectors on 10.200.5.100:8888
 listenaddr: 10.200.5.100
 listenport: 8888

--- a/doc/exampleconfigs/provisioner-example.yaml
+++ b/doc/exampleconfigs/provisioner-example.yaml
@@ -8,6 +8,10 @@ clientport: 9001
 mediationaddr: 10.0.0.1
 mediationport: 12001
 
+tlscert: server-crt.pem
+tlskey: server-key.pem
+tlsca: ca-crt.pem
+
 # List of SIP servers on our network (for managing VOIP intercepts)
 sipservers:
   - ip: 192.168.110.100

--- a/gitlab-build-rpm.sh
+++ b/gitlab-build-rpm.sh
@@ -1,0 +1,72 @@
+set -x -e -o pipefail
+
+if [ "${CI_COMMIT_REF_NAME}" = "" ]; then
+        CI_COMMIT_REF_NAME=1.0.2
+fi
+
+export QA_RPATHS=$[ 0x0001 ]
+SOURCENAME=`echo ${CI_COMMIT_REF_NAME} | cut -d '-' -f 1`
+
+
+DISTRO=fedora
+if [ "$1" = "centos7" ]; then
+        DISTRO=centos
+fi
+
+if [ "$1" = "centos6" ]; then
+        DISTRO=centos
+fi
+
+cat << EOF > /etc/yum.repos.d/bintray-wand-general-rpm.repo
+#bintray-wand-general-rpm - packages by wand from Bintray
+[bintray-wand-general-rpm]
+name=bintray-wand-general-rpm
+baseurl=https://dl.bintray.com/wand/general-rpm/${DISTRO}/\$releasever/\$basearch/
+gpgkey=https://bintray.com/user/downloadSubjectPublicKey?username=wand
+gpgcheck=0
+repo_gpgcheck=1
+enabled=1
+EOF
+
+cat << EOF > /etc/yum.repos.d/bintray-wand-libtrace-rpm.repo
+#bintray-wand-libtrace-rpm - packages by wand from Bintray
+[bintray-wand-libtrace-rpm]
+name=bintray-wand-libtrace-rpm
+baseurl=https://dl.bintray.com/wand/libtrace-rpm/${DISTRO}/\$releasever/\$basearch/
+gpgkey=https://bintray.com/user/downloadSubjectPublicKey?username=wand
+gpgcheck=0
+repo_gpgcheck=1
+enabled=1
+EOF
+
+yum install -y wget make gcc
+
+if [ "$1" = "centos7" ]; then
+        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true
+        yum install -y http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm || true
+fi
+
+if [ "$1" = "centos6" ]; then
+        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm || true
+        yum install -y epel-rpm-macros
+fi
+
+
+if [[ "$1" =~ fedora* ]]; then
+        dnf install -y rpm-build rpmdevtools 'dnf-command(builddep)' which
+        dnf group install -y "C Development Tools and Libraries"
+        dnf builddep -y rpm/openli.spec
+else
+        yum install -y rpm-build yum-utils rpmdevtools which
+        yum groupinstall -y 'Development Tools'
+        yum-builddep -y rpm/openli.spec
+fi
+
+rpmdev-setuptree
+
+./bootstrap.sh && ./configure && make dist
+cp openli-*.tar.gz ~/rpmbuild/SOURCES/${SOURCENAME}.tar.gz
+cp rpm/openli.spec ~/rpmbuild/SPECS/
+
+cd ~/rpmbuild && rpmbuild -bb --define "debug_package %{nil}" SPECS/openli.spec
+

--- a/gitlab-build-rpm.sh
+++ b/gitlab-build-rpm.sh
@@ -39,11 +39,21 @@ repo_gpgcheck=1
 enabled=1
 EOF
 
+cat << EOF > /etc/yum.repos.d/bintray-wand-openli-rpm.repo
+#bintray-wand-openli-rpm - packages by wand from Bintray
+[bintray-wand-openli-rpm]
+name=bintray-wand-openli-rpm
+baseurl=https://dl.bintray.com/wand/OpenLI-rpm/${DISTRO}/\$releasever/\$basearch/
+gpgkey=https://bintray.com/user/downloadSubjectPublicKey?username=wand
+gpgcheck=0
+repo_gpgcheck=1
+enabled=1
+EOF
+
 yum install -y wget make gcc
 
 if [ "$1" = "centos7" ]; then
         yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true
-        yum install -y http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm || true
 fi
 
 if [ "$1" = "centos6" ]; then

--- a/gitlab-build.sh
+++ b/gitlab-build.sh
@@ -6,6 +6,8 @@ export DEBEMAIL='packaging@wand.net.nz'
 export DEBFULLNAME='WAND Packaging'
 export DEBIAN_FRONTEND=noninteractive
 
+SOURCENAME=`echo ${CI_COMMIT_REF_NAME} | cut -d '-' -f 1`
+
 apt-get update
 apt-get install -y equivs devscripts dpkg-dev quilt curl apt-transport-https \
     apt-utils ssl-cert ca-certificates gnupg lsb-release debhelper git
@@ -21,6 +23,6 @@ curl --silent "https://bintray.com/user/downloadSubjectPublicKey?username=wand"\
 apt-get update
 apt-get upgrade -y
 
-dpkg-parsechangelog -S version | grep -q ${CI_COMMIT_REF_NAME} || debchange --newversion ${CI_COMMIT_REF_NAME} -b "New upstream release"
+dpkg-parsechangelog -S version | grep -q ${SOURCENAME} || debchange --newversion ${SOURCENAME} -b "New upstream release"
 mk-build-deps -i -r -t 'apt-get -f -y --force-yes'
 dpkg-buildpackage -b -us -uc -rfakeroot -j4

--- a/rpm/openli.spec
+++ b/rpm/openli.spec
@@ -1,6 +1,6 @@
 Name:           openli
-Version:        1.0.2
-Release:        2%{?dist}
+Version:        1.0.3
+Release:        1%{?dist}
 Summary:        Software for performing ETSI-compliant lawful intercept
 
 License:        GPLv3
@@ -169,6 +169,9 @@ fi
 
 
 %changelog
+* Tue Jun 25 2019 Shane Alcock <salcock@waikato.ac.nz> - 1.0.3-1
+- Updated for 1.0.3 release
+
 * Tue Jun 18 2019 Shane Alcock <salcock@waikato.ac.nz> - 1.0.2-2
 - Add openssl-devel dependency for encrypted communications
 

--- a/rpm/openli.spec
+++ b/rpm/openli.spec
@@ -1,0 +1,172 @@
+Name:           openli
+Version:        1.0.2
+Release:        1%{?dist}
+Summary:        Software for performing ETSI-compliant lawful intercept
+
+License:        GPLv3
+URL:            https://github.com/wanduow/OpenLI
+Source0:        https://github.com/wanduow/OpenLI/archive/%{version}.tar.gz
+
+BuildRequires: gcc
+BuildRequires: gcc-c++
+BuildRequires: make
+BuildRequires: bison
+BuildRequires: doxygen
+BuildRequires: flex
+BuildRequires: libyaml-devel
+BuildRequires: libtrace4-devel
+BuildRequires: Judy-devel
+BuildRequires: uthash-devel
+BuildRequires: libwandder1-devel
+BuildRequires: zeromq-devel
+BuildRequires: gperftools-devel
+BuildRequires: libosip2-devel
+BuildRequires: systemd
+
+%description
+Software for performing ETSI-compliant lawful intercept
+
+%package        provisioner
+Summary:        Central provisioning daemon for an OpenLI system
+
+%description provisioner
+OpenLI is a software suite that allows network operators to conduct
+lawful interception of Internet traffic that is compliant with the
+ETSI Lawful Intercept standards.
+This package contains the provisioner component of the OpenLI
+lawful intercept software. The provisioner acts as a centralised
+controller for the deployed OpenLI collectors and mediators.
+Intercepts are configured on the provisioner, which then pushes
+the necessary intercept instructions to any registered collectors
+and mediators.
+
+%package        mediator
+Summary:        Mediation daemon for an OpenLI system
+
+%description mediator
+OpenLI is a software suite that allows network operators to conduct
+lawful interception of Internet traffic that is compliant with the
+ETSI Lawful Intercept standards.
+This package contains the mediator component of the OpenLI
+lawful intercept software. The mediator collates intercepted
+(and encoded) packets from the collectors and routes the packets
+to the appropriate law enforcement agency (LEA). The mediator will
+maintain active TCP sessions to all known LEAs for both handover
+interface 2 and 3, using keep-alives as per the ETSI standard.
+
+%package        collector
+Summary:        Collector daemon for an OpenLI system
+
+%description collector
+OpenLI is a software suite that allows network operators to conduct
+lawful interception of Internet traffic that is compliant with the
+ETSI Lawful Intercept standards.
+This package contains the collector component of the OpenLI lawful
+intercept software. The collector captures packets on one or more
+specified network interfaces, identifies traffic that should be
+intercepted (based on instructions from an OpenLI provisioner),
+encodes the intercepted traffic using the format described in the
+ETSI specifications, and forwards the encoded traffic to the
+appropriate mediator for export to the law enforcement agency that
+requested the intercept.
+
+
+
+%prep
+%setup -q -n openli-%{version}
+
+%build
+%configure --disable-static --with-man=yes --mandir=%{_mandir} --sysconfdir=/etc/
+make %{?_smp_mflags}
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%make_install
+find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
+
+%post provisioner
+if [ $1 -eq 1 ]; then
+        /bin/systemctl enable openli-provisioner.service openli-provisioner.socket >/dev/null 2>&1 || :
+fi
+
+%preun provisioner
+if [ $1 -eq 0 ]; then
+        # Disable and stop the units
+        /bin/systemctl disable openli-provisioner.service openli-provisioner.socket >/dev/null 2>&1 || :
+        /bin/systemctl stop openli-provisioner.service openli-provisioner.socket >/dev/null 2>&1 || :
+fi
+
+%postun provisioner
+if [ $1 -ge 1 ]; then
+        # On upgrade, reload init system configuration if we changed unit files
+        /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+        # On upgrade, restart the daemon
+        /bin/systemctl try-restart openli-provisioner.service >/dev/null 2>&1 || :
+fi
+
+%post mediator
+if [ $1 -eq 1 ]; then
+        /bin/systemctl enable openli-mediator.service openli-mediator.socket >/dev/null 2>&1 || :
+fi
+
+%preun mediator
+if [ $1 -eq 0 ]; then
+        # Disable and stop the units
+        /bin/systemctl disable openli-mediator.service openli-mediator.socket >/dev/null 2>&1 || :
+        /bin/systemctl stop openli-mediator.service openli-mediator.socket >/dev/null 2>&1 || :
+fi
+
+%postun mediator
+if [ $1 -ge 1 ]; then
+        # On upgrade, reload init system configuration if we changed unit files
+        /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+        # On upgrade, restart the daemon
+        /bin/systemctl try-restart openli-mediator.service >/dev/null 2>&1 || :
+fi
+
+%post collector
+if [ $1 -eq 1 ]; then
+        /bin/systemctl enable openli-collector.service openli-collector.socket >/dev/null 2>&1 || :
+fi
+
+%preun collector
+if [ $1 -eq 0 ]; then
+        # Disable and stop the units
+        /bin/systemctl disable openli-collector.service openli-collector.socket >/dev/null 2>&1 || :
+        /bin/systemctl stop openli-collector.service openli-collector.socket >/dev/null 2>&1 || :
+fi
+
+%postun collector
+if [ $1 -ge 1 ]; then
+        # On upgrade, reload init system configuration if we changed unit files
+        /bin/systemctl daemon-reload >/dev/null 2>&1 || :
+        # On upgrade, restart the daemon
+        /bin/systemctl try-restart openli-collector.service >/dev/null 2>&1 || :
+fi
+
+%files provisioner
+%{_bindir}/openliprovisioner
+%{_unitdir}/openli-provisioner.service
+%config %{_sysconfdir}/rsyslog.d/10-openli-provisioner.conf
+%config %{_sysconfdir}/openli/provisioner-example.yaml
+%doc %{_docdir}/openli/ProvisionerDoc.md
+
+%files mediator
+%{_bindir}/openlimediator
+%{_unitdir}/openli-mediator.service
+%config %{_sysconfdir}/rsyslog.d/10-openli-mediator.conf
+%config %{_sysconfdir}/openli/mediator-example.yaml
+%doc %{_docdir}/openli/MediatorDoc.md
+
+%files collector
+%{_bindir}/openlicollector
+%{_unitdir}/openli-collector.service
+%config %{_sysconfdir}/rsyslog.d/10-openli-collector.conf
+%config %{_sysconfdir}/openli/collector-example.yaml
+%doc %{_docdir}/openli/CollectorDoc.md
+
+
+%changelog
+* Tue Jun 4 2019 Shane Alcock <salcock@waikato.ac.nz> - 1.0.2-1
+- First OpenLI RPM package

--- a/rpm/openli.spec
+++ b/rpm/openli.spec
@@ -1,6 +1,6 @@
 Name:           openli
 Version:        1.0.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Software for performing ETSI-compliant lawful intercept
 
 License:        GPLv3
@@ -21,6 +21,7 @@ BuildRequires: libwandder1-devel
 BuildRequires: zeromq-devel
 BuildRequires: gperftools-devel
 BuildRequires: libosip2-devel
+BuildRequires: openssl-devel
 BuildRequires: systemd
 
 %description
@@ -168,5 +169,8 @@ fi
 
 
 %changelog
+* Tue Jun 18 2019 Shane Alcock <salcock@waikato.ac.nz> - 1.0.2-2
+- Add openssl-devel dependency for encrypted communications
+
 * Tue Jun 4 2019 Shane Alcock <salcock@waikato.ac.nz> - 1.0.2-1
 - First OpenLI RPM package

--- a/src/collector/alushim_parser.c
+++ b/src/collector/alushim_parser.c
@@ -164,8 +164,14 @@ int check_alu_intercept(collector_identity_t *info, colthread_local_t *loc,
             case TRACE_ETHERTYPE_PPP_SES:
                 l3 = trace_get_payload_from_pppoe(l3, &ethertype, &rem);
                 continue;
-            default:
+            case TRACE_ETHERTYPE_ARP:
+                /* Probably shouldn't be intercepting ARP */
+                return 0;
+            case TRACE_ETHERTYPE_IP:
+            case TRACE_ETHERTYPE_IPV6:
                 break;
+            default:
+                return 0;
         }
         break;
     }

--- a/src/collector/collector.c
+++ b/src/collector/collector.c
@@ -1032,6 +1032,9 @@ static void destroy_collector_state(collector_global_t *glob) {
     if (glob->collocals) {
         free(glob->collocals);
     }
+    if(glob->ctx){
+        SSL_CTX_free(glob->ctx);
+    }
     free(glob);
 }
 
@@ -1193,6 +1196,11 @@ static collector_global_t *parse_global_config(char *configfile) {
     glob->nextloc = 0;
     glob->syncgenericfreelist = NULL;
 
+    glob->certfile = NULL;
+    glob->keyfile = NULL;
+    glob->cacertfile = NULL;
+    glob->etsitls = 1;
+
     memset(&(glob->stats), 0, sizeof(glob->stats));
     glob->stat_frequency = 0;
     glob->ticks_since_last_stat = 0;
@@ -1206,6 +1214,23 @@ static collector_global_t *parse_global_config(char *configfile) {
     if (parse_collector_config(configfile, glob) == -1) {
         clear_global_config(glob);
         return NULL;
+    }
+
+    logger(LOG_DEBUG, "OpenLI: ETSI TLS encryption %s",
+        glob->etsitls ? "enabled" : "disabled");
+
+    if (glob->certfile && glob->keyfile && glob->cacertfile){
+        glob->ctx = ssl_init(glob->cacertfile, glob->certfile, glob->keyfile);
+    } else {
+        if (glob->certfile || glob->keyfile || glob->cacertfile){
+            logger(LOG_INFO, "OpenLI: SSL error, missing keyfile or certfile names.");
+            clear_global_config(glob);
+            return NULL;
+        }
+        else{
+            logger(LOG_DEBUG, "OpenLI: Not using OpenSSL TLS connection.");
+            glob->ctx = NULL;
+        }
     }
 
     if (glob->sharedinfo.provisionerport == NULL) {
@@ -1239,7 +1264,6 @@ static int reload_collector_config(collector_global_t *glob,
         collector_sync_t *sync) {
 
     collector_global_t *newstate;
-
     newstate = parse_global_config(glob->configfile);
     if (newstate == NULL) {
         logger(LOG_INFO,
@@ -1361,7 +1385,7 @@ static void *start_ip_sync_thread(void *params) {
             reload_config = 0;
         }
         if (sync->instruct_fd == -1) {
-            ret = sync_connect_provisioner(sync);
+            ret = sync_connect_provisioner(sync, glob->ctx);
             if (ret < 0) {
                 /* Fatal error */
                 logger(LOG_INFO,
@@ -1513,6 +1537,8 @@ int main(int argc, char *argv[]) {
         glob->forwarders[i].colthreads = glob->total_col_threads;
         glob->forwarders[i].zmq_ctrlsock = NULL;
         glob->forwarders[i].zmq_pullressock = NULL;
+        glob->forwarders[i].ctx = (glob->ctx && glob->etsitls) ? glob->ctx : NULL;
+        //forwarder only needs CTX if ctx exists and is enabled 
 
         pthread_create(&(glob->forwarders[i].threadid), NULL,
                 start_forwarding_thread, (void *)&(glob->forwarders[i]));

--- a/src/collector/collector.h
+++ b/src/collector/collector.h
@@ -36,6 +36,10 @@
 #include <libwandder.h>
 #include <zmq.h>
 
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+
 #include "patricia.h"
 #include "coreserver.h"
 #include "intercept.h"
@@ -256,6 +260,13 @@ typedef struct collector_global {
     uint64_t ticks_since_last_stat;
     collector_stats_t stats;
     pthread_mutex_t stats_mutex;
+
+    char *keyfile;
+    char *certfile;
+    char *cacertfile;
+    uint8_t etsitls;
+
+    SSL_CTX *ctx;
 
 } collector_global_t;
 

--- a/src/collector/collector_base.h
+++ b/src/collector/collector_base.h
@@ -50,6 +50,9 @@ typedef struct export_dest {
     export_buffer_t buffer;
     uint8_t logallowed;
 
+    SSL *ssl;
+    int waitingforhandshake;
+
     UT_hash_handle hh_fd;
     UT_hash_handle hh_medid;
 } export_dest_t;
@@ -173,6 +176,8 @@ typedef struct forwarding_thread_data {
 
     Pvoid_t intreorderer_cc;
     Pvoid_t intreorderer_iri;
+
+    SSL_CTX *ctx;
 
 } forwarding_thread_data_t;
 

--- a/src/collector/collector_sync.h
+++ b/src/collector/collector_sync.h
@@ -53,6 +53,7 @@ typedef struct colsync_data {
     internet_user_t *allusers;
     ipintercept_t *ipintercepts;
     user_intercept_list_t *userintercepts;
+    voipintercept_t *knownvoips;
 
     coreserver_t *coreservers;
 
@@ -72,12 +73,15 @@ typedef struct colsync_data {
 
     ip_to_session_t *activeips;
 
+    SSL *ssl;
+    SSL_CTX *ctx;
+
 } collector_sync_t;
 
 collector_sync_t *init_sync_data(collector_global_t *glob);
 void clean_sync_data(collector_sync_t *sync);
 void sync_disconnect_provisioner(collector_sync_t *sync);
-int sync_connect_provisioner(collector_sync_t *sync);
+int sync_connect_provisioner(collector_sync_t *sync, SSL_CTX *ctx);
 void sync_thread_publish_reload(collector_sync_t *sync);
 int sync_thread_main(collector_sync_t *sync);
 

--- a/src/configparser.c
+++ b/src/configparser.c
@@ -946,6 +946,30 @@ static int global_parser(void *arg, yaml_document_t *doc,
                 NULL, 10);
     }
 
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "tlscert") == 0) {
+        SET_CONFIG_STRING_OPTION(glob->certfile, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "tlskey") == 0) {
+        SET_CONFIG_STRING_OPTION(glob->keyfile, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "tlsca") == 0) {
+        SET_CONFIG_STRING_OPTION(glob->cacertfile, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "etsitls") == 0) {
+            glob->etsitls = check_onoff(value->data.scalar.value);
+    }
+    
     return 0;
 }
 
@@ -1011,6 +1035,30 @@ static int mediator_parser(void *arg, yaml_document_t *doc,
             logger(LOG_INFO, "OpenLI: 0 is not a valid value for the 'pcaprotatefreq' config option.");
             return -1;
         }
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "tlscert") == 0) {
+        SET_CONFIG_STRING_OPTION(state->certfile, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "tlskey") == 0) {
+        SET_CONFIG_STRING_OPTION(state->keyfile, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "tlsca") == 0) {
+        SET_CONFIG_STRING_OPTION(state->cacertfile, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "etsitls") == 0) {
+            state->etsitls = check_onoff(value->data.scalar.value);
     }
 
     return 0;
@@ -1108,6 +1156,25 @@ static int provisioning_parser(void *arg, yaml_document_t *doc,
             strcmp((char *)key->data.scalar.value, "mediationaddr") == 0) {
         SET_CONFIG_STRING_OPTION(state->mediateaddr, value);
     }
+
+   if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "tlscert") == 0) {
+        SET_CONFIG_STRING_OPTION(state->certfile, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "tlskey") == 0) {
+        SET_CONFIG_STRING_OPTION(state->keyfile, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
+            strcmp((char *)key->data.scalar.value, "tlsca") == 0) {
+        SET_CONFIG_STRING_OPTION(state->cacertfile, value);
+    }
+
     return 0;
 }
 

--- a/src/export_buffer.c
+++ b/src/export_buffer.c
@@ -163,7 +163,7 @@ uint64_t append_message_to_buffer(export_buffer_t *buf,
 }
 
 int transmit_buffered_records(export_buffer_t *buf, int fd,
-        uint64_t bytelimit) {
+        uint64_t bytelimit, SSL *ssl) {
 
     uint64_t sent = 0;
     uint64_t rem = 0;
@@ -174,8 +174,20 @@ int transmit_buffered_records(export_buffer_t *buf, int fd,
 
     sent = (buf->buftail - (bhead + offset));
 
-    if (sent != 0) {
-        ret = send(fd, bhead + offset, (int)sent, MSG_DONTWAIT);
+    if (sent != 0) {        
+
+        if (ssl != NULL){
+            ret = SSL_write(ssl, bhead + offset, (int)sent);
+            
+            if ((ret) <= 0 ){
+                int errr = SSL_get_error(ssl, ret);
+                logger(LOG_INFO, "OpenLI: ssl_write error in export_buffer");
+            }
+        }
+        else {
+           ret = send(fd, bhead + offset, (int)sent, MSG_DONTWAIT);
+        }
+
         if (ret < 0) {
             if (errno != EAGAIN) {
                 return -1;

--- a/src/export_buffer.h
+++ b/src/export_buffer.h
@@ -66,7 +66,7 @@ uint64_t append_message_to_buffer(export_buffer_t *buf,
 uint64_t append_etsipdu_to_buffer(export_buffer_t *buf,
         uint8_t *pdustart, uint32_t pdulen, uint32_t beensent);
 int transmit_buffered_records(export_buffer_t *buf, int fd,
-        uint64_t bytelimit);
+        uint64_t bytelimit, SSL *ssl);
 
 #endif
 // vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/src/mediator/mediator.c
+++ b/src/mediator/mediator.c
@@ -183,6 +183,11 @@ static inline void setup_provisioner_reconnect_timer(mediator_state_t *state) {
 static void free_provisioner(int epollfd, mediator_prov_t *prov) {
     struct epoll_event ev;
 
+    if (prov->ssl){
+        SSL_free(prov->ssl);
+        prov->ssl = NULL;
+    }
+
     if (prov->provev) {
         if (prov->provev->fd != -1) {
             if (epoll_ctl(epollfd, EPOLL_CTL_DEL, prov->provev->fd,
@@ -318,6 +323,9 @@ static void drop_all_collectors(mediator_state_t *state, libtrace_list_t *c) {
         drop_collector(state, col->colev, 0);
         free(col->colev->state);
         free(col->colev);
+        if (col->ssl){
+            SSL_free(col->ssl);
+        }
         n = n->next;
     }
 
@@ -358,6 +366,9 @@ static void clear_med_config(mediator_state_t *state) {
     }
     if (state->operatorid) {
         free(state->operatorid);
+    }
+    if(state->ctx){
+        SSL_CTX_free(state->ctx);
     }
     pthread_mutex_destroy(&(state->agency_mutex));
 }
@@ -456,6 +467,12 @@ static int init_med_state(mediator_state_t *state, char *configfile,
     state->mediatorname = mediatorname;
     state->listenaddr = NULL;
     state->listenport = NULL;
+    state->etsitls = 1;
+
+    state->certfile = NULL;
+    state->keyfile = NULL;
+    state->cacertfile = NULL;
+
     state->operatorid = NULL;
     state->provaddr = NULL;
     state->provport = NULL;
@@ -473,6 +490,7 @@ static int init_med_state(mediator_state_t *state, char *configfile,
     state->provisioner.outgoing = NULL;
     state->provisioner.disable_log = 0;
     state->provisioner.tryconnect = 1;
+    state->provisioner.ssl = NULL;
     state->collectors = NULL;
     state->agencies = NULL;
     state->epoll_fd = -1;
@@ -489,6 +507,22 @@ static int init_med_state(mediator_state_t *state, char *configfile,
 
     if (parse_mediator_config(configfile, state) == -1) {
         return -1;
+    }
+
+    logger(LOG_DEBUG, "OpenLI: ETSI TLS encryption %s",
+        state->etsitls ? "enabled" : "disabled");
+
+    if (state->certfile && state->keyfile && state->cacertfile){
+        state->ctx = ssl_init(state->cacertfile, state->certfile, state->keyfile);
+    } else {
+        if (state->certfile || state->keyfile || state->cacertfile){
+            logger(LOG_INFO, "OpenLI: SSL error, missing keyfile or certfile names.");
+            return -1;
+        }
+        else{
+            logger(LOG_DEBUG, "OpenLI: Not using OpenSSL TLS connection.");
+            state->ctx = NULL;
+        }
     }
 
     if (state->mediatorid == 0) {
@@ -870,6 +904,7 @@ static int accept_collector(mediator_state_t *state) {
     /* Accept, then add to list of collectors. Push all active intercepts
      * out to the collector. */
     newfd = accept(state->listenerev->fd, (struct sockaddr *)&saddr, &socklen);
+    fd_set_nonblock(newfd);
 
     if (getnameinfo((struct sockaddr *)&saddr, socklen, strbuf, sizeof(strbuf),
                 0, 0, NI_NUMERICHOST) != 0) {
@@ -878,13 +913,52 @@ static int accept_collector(mediator_state_t *state) {
     }
 
     if (newfd >= 0) {
+
         mstate = (med_coll_state_t *)malloc(sizeof(med_coll_state_t));
         col.colev = (med_epoll_ev_t *)malloc(sizeof(prov_epoll_ev_t));
 
-        col.colev->fdtype = MED_EPOLL_COLLECTOR;
+        //only use TLS if ctx is set AND tls is not disabled for mediator/collector
+        if (state->ctx != NULL && state->etsitls == 1){
+            col.ssl = SSL_new(state->ctx);
+            SSL_set_fd(col.ssl, newfd);
+
+            int errr = SSL_accept(col.ssl);
+            if (errr <= 0){
+                errr = SSL_get_error(col.ssl, errr);
+
+                if (errr != SSL_ERROR_WANT_WRITE &&
+                    errr != SSL_ERROR_WANT_READ && 
+                    errr != SSL_ERROR_WANT_ACCEPT &&
+                    errr != SSL_ERROR_WANT_CONNECT){ //handshake failed badly
+                    ERR_print_errors_fp(stderr);
+                    close(newfd);
+                    SSL_free(col.ssl);
+                    free(mstate);
+                    free(col.colev);
+                    logger(LOG_INFO, "OpenLI: SSL Handshake failed");
+                    return -1;
+                }
+                logger(LOG_DEBUG, "OpenLI: SSL Handshake started");
+                col.colev->fdtype = MED_EPOLL_COLLECTOR_HANDSHAKE;
+            }
+            else {
+                logger(LOG_DEBUG, "OpenLI: SSL Handshake accepted");
+                dump_cert_info(col.ssl);
+
+                //handshake has finished
+                col.colev->fdtype = MED_EPOLL_COLLECTOR;
+
+            }
+        } else {
+            col.colev->fdtype = MED_EPOLL_COLLECTOR;
+            col.ssl = NULL;
+        }
+
+        
         col.colev->fd = newfd;
         col.colev->state = mstate;
-        mstate->incoming = create_net_buffer(NETBUF_RECV, newfd);
+        mstate->ssl = col.ssl;
+        mstate->incoming = create_net_buffer(NETBUF_RECV, newfd, col.ssl);
         mstate->ipaddr = strdup(strbuf);
 
         HASH_FIND(hh, state->disabledcols, mstate->ipaddr,
@@ -1431,7 +1505,7 @@ static inline int xmit_handover(mediator_state_t *state, med_epoll_ev_t *mev) {
         return 0;
     }
 
-    if ((ret = transmit_buffered_records(&(mas->buf), mev->fd, 65535)) == -1) {
+    if ((ret = transmit_buffered_records(&(mas->buf), mev->fd, 65535, NULL)) == -1) { //handover doesnt use TLS, so NULL
         return -1;
     }
 
@@ -1957,6 +2031,30 @@ static int receive_collector(mediator_state_t *state, med_epoll_ev_t *mev) {
     return 0;
 }
 
+static int continue_handshake(mediator_state_t *state, med_epoll_ev_t *mev) {
+    med_coll_state_t *cs = (med_coll_state_t *)(mev->state);
+
+    int ret = SSL_accept(cs->ssl); //either keep running handshake or return when error 
+
+    if (ret <= 0){
+        ret = SSL_get_error(cs->ssl, ret);
+        if(ret == SSL_ERROR_WANT_READ || ret == SSL_ERROR_WANT_WRITE){
+            //keep trying
+            return 0;
+        }
+        else {
+            //fail out
+            logger(LOG_INFO, "OpenLI: SSL Handshake failed");
+            return -1;
+        }
+    }
+    logger(LOG_DEBUG, "OpenLI: SSL Handshake accepted");
+    dump_cert_info(cs->ssl);
+
+    //handshake has finished
+    mev->fdtype = MED_EPOLL_COLLECTOR;
+}
+
 static int check_epoll_fd(mediator_state_t *state, struct epoll_event *ev) {
 
 	med_epoll_ev_t *mev = (med_epoll_ev_t *)(ev->data.ptr);
@@ -2042,6 +2140,14 @@ static int check_epoll_fd(mediator_state_t *state, struct epoll_event *ev) {
                 state->provisioner.disable_log = 1;
             }
             break;
+        case MED_EPOLL_COLLECTOR_HANDSHAKE:{
+                //continue handshake process
+                ret = continue_handshake(state, mev);
+                if (ret == -1) {
+                    drop_collector(state, mev, 1);
+                }
+            }
+            break;
         case MED_EPOLL_COLLECTOR:
             if (ev->events & EPOLLRDHUP) {
                 ret = -1;
@@ -2123,7 +2229,7 @@ static int send_mediator_listen_details(mediator_state_t *state,
     return 0;
 }
 
-static int init_provisioner_connection(mediator_state_t *state, int sock) {
+static int init_provisioner_connection(mediator_state_t *state, int sock, SSL_CTX *ctx) {
 
     struct epoll_event ev;
     mediator_prov_t *prov = (mediator_prov_t *)&(state->provisioner);
@@ -2137,9 +2243,40 @@ static int init_provisioner_connection(mediator_state_t *state, int sock) {
     prov->provev->fdtype = MED_EPOLL_PROVISIONER;
     prov->provev->state = NULL;
 
+    if (ctx != NULL){
+
+        fd_set_block(sock); 
+        //mediator cannt do anything untill it has instructions fom provisioner so blocking is fine
+
+        int errr;
+        prov->ssl = SSL_new(ctx);
+        SSL_set_fd(prov->ssl, sock);
+        
+        errr = SSL_connect(prov->ssl);
+        fd_set_nonblock(sock); 
+        if(errr <= 0){
+            errr = SSL_get_error(prov->ssl, errr);
+            if (errr != SSL_ERROR_WANT_WRITE && errr != SSL_ERROR_WANT_READ){ //handshake failed badly
+                //close(sock);
+                SSL_free(prov->ssl);
+                free(prov->provev);
+                prov->ssl = NULL;
+                logger(LOG_INFO, "OpenLI: SSL Handshake failed");
+                return -1;
+            }
+        }
+        logger(LOG_DEBUG, "OpenLI: SSL Handshake started");
+        dump_cert_info(prov->ssl);
+    }
+    else {
+        prov->ssl = NULL;
+    }
+
+
+
     prov->sentinfo = 0;
-    prov->outgoing = create_net_buffer(NETBUF_SEND, sock);
-    prov->incoming = create_net_buffer(NETBUF_RECV, sock);
+    prov->outgoing = create_net_buffer(NETBUF_SEND, sock, prov->ssl);
+    prov->incoming = create_net_buffer(NETBUF_RECV, sock, prov->ssl);
 
     ev.data.ptr = prov->provev;
     ev.events = EPOLLIN | EPOLLOUT | EPOLLRDHUP;
@@ -2388,7 +2525,7 @@ static void run(mediator_state_t *state) {
                         state->provaddr, state->provport);
             }
 
-            if (init_provisioner_connection(state, s) == -1) {
+            if (init_provisioner_connection(state, s, state->ctx) == -1) {
                 destroy_net_buffer(state->provisioner.outgoing);
                 destroy_net_buffer(state->provisioner.incoming);
                 close(s);
@@ -2420,7 +2557,8 @@ static void run(mediator_state_t *state) {
                 logger(LOG_INFO,
 						"OpenLI: error while waiting for epoll events in mediator: %s.",
                         strerror(errno));
-                return;
+                mediator_halt = true;
+                continue;
             }
 
             for (i = 0; i < nfds; i++) {
@@ -2436,12 +2574,13 @@ static void run(mediator_state_t *state) {
             logger(LOG_INFO,
                 "OpenLI: unable to remove mediator timer from epoll set: %s",
                 strerror(errno));
-            return;
+            break;
         }
 
         close(timerfd);
 		state->timerev->fd = -1;
     }
+    mediator_halt = true;
 
 }
 

--- a/src/mediator/mediator.h
+++ b/src/mediator/mediator.h
@@ -53,6 +53,7 @@ enum {
     MED_EPOLL_PCAP_TIMER,
     MED_EPOLL_CEASE_LIID_TIMER,
     MED_EPOLL_PROVRECONNECT,
+    MED_EPOLL_COLLECTOR_HANDSHAKE,
 };
 
 typedef struct disabled_collector {
@@ -64,6 +65,7 @@ typedef struct med_coll_state {
     char *ipaddr;
     net_buffer_t *incoming;
     int disabled_log;
+    SSL *ssl;
 } med_coll_state_t;
 
 typedef struct handover {
@@ -94,6 +96,7 @@ typedef struct med_agency_state {
 
 typedef struct mediator_collector {
     med_epoll_ev_t *colev;
+    SSL *ssl;
 } mediator_collector_t;
 
 typedef struct mediator_provisioner {
@@ -103,6 +106,7 @@ typedef struct mediator_provisioner {
     net_buffer_t *incoming;
     uint8_t disable_log;
     uint8_t tryconnect;
+    SSL *ssl;
 } mediator_prov_t;
 
 enum {
@@ -127,6 +131,10 @@ typedef struct med_state {
     char *operatorid;
     char *listenaddr;
     char *listenport;
+    char *keyfile;
+    char *certfile;
+    char *cacertfile;
+    uint8_t etsitls;
 
     char *provaddr;
     char *provport;
@@ -155,6 +163,7 @@ typedef struct med_state {
     libtrace_message_queue_t pcapqueue;
     wandder_etsispec_t *etsidecoder;
     disabled_collector_t *disabledcols;
+    SSL_CTX *ctx;
 
 } mediator_state_t;
 

--- a/src/netcomms.c
+++ b/src/netcomms.c
@@ -54,7 +54,7 @@ static inline void dump_buffer_contents(uint8_t *buf, uint16_t len) {
 
 }
 
-net_buffer_t *create_net_buffer(net_buffer_type_t buftype, int fd) {
+net_buffer_t *create_net_buffer(net_buffer_type_t buftype, int fd, SSL *ssl) {
 
     net_buffer_t *nb = (net_buffer_t *)malloc(sizeof(net_buffer_t));
     nb->buf = (char *)malloc(NETBUF_ALLOC_SIZE);
@@ -63,6 +63,7 @@ net_buffer_t *create_net_buffer(net_buffer_type_t buftype, int fd) {
     nb->alloced = NETBUF_ALLOC_SIZE;
     nb->fd = fd;
     nb->buftype = buftype;
+    nb->ssl = ssl;
     return nb;
 }
 
@@ -72,6 +73,106 @@ void destroy_net_buffer(net_buffer_t *nb) {
     }
     free(nb->buf);
     free(nb);
+}
+
+inline int fd_set_nonblock(int fd){
+    int flags = fcntl(fd, F_GETFL, 0);
+    flags |= O_NONBLOCK;
+    return fcntl(fd, F_SETFL, flags);
+}
+
+inline int fd_set_block(int fd){
+    int flags = fcntl(fd, F_GETFL, 0);
+    flags &= ~O_NONBLOCK;
+    return fcntl(fd, F_SETFL, flags);
+}
+
+void dump_cert_info(SSL *ssl) {
+    
+    logger(LOG_DEBUG,
+        "SSL connection version: %s", 
+        SSL_get_version(ssl)); //should ALWAYS be TLSv1_2
+
+    logger(LOG_DEBUG,
+        "Using cipher %s", 
+        SSL_get_cipher(ssl)); //should ALWAYS be AES256-GCM-SHA384
+
+    X509 *client_cert = SSL_get_peer_certificate(ssl);
+    if (client_cert != NULL) {
+
+        char *str = X509_NAME_oneline(X509_get_subject_name(client_cert), 0, 0);
+        logger(LOG_DEBUG,"Connection certificate: Subject: %s", str);
+        OPENSSL_free(str);
+
+        str = X509_NAME_oneline(X509_get_issuer_name(client_cert), 0, 0);
+        logger(LOG_DEBUG,"Connection certificate: Issuer: %s\n", str);
+        OPENSSL_free(str);
+
+        X509_free(client_cert);
+    }
+}
+
+//takes in 3 filenames for the CA, own cert and private key
+//if all 3 files names are null, returns null as successfully doing nothing
+//returns -1 if an error happened
+//otherwise returns a new SSL_CTX with the provided certificates using TLSv1_2
+//and enforces identity checking at handshake
+SSL_CTX * ssl_init(const char *cacertfile, const char *certfile, const char *keyfile) {
+
+    /* SSL library initialisation */
+    SSL_library_init();
+    OpenSSL_add_all_algorithms();
+    SSL_load_error_strings();
+    ERR_load_crypto_strings();
+    
+    /* create the SSL context */
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    SSL_CTX *ctx = SSL_CTX_new(TLSv1_2_method());
+#else
+    SSL_CTX *ctx = SSL_CTX_new(TLS_method());
+#endif
+
+    if (!ctx){ //check not NULL
+        logger(LOG_INFO, "OpenLI: SSL_CTX creation failed");
+        return NULL;
+    }
+
+    /* Enforce use of TLSv1_2 */
+    SSL_CTX_set_options(ctx, SSL_OP_ALL | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
+
+    if (SSL_CTX_load_verify_locations(ctx, cacertfile, "./") != 1){ //TODO this might want to be changed
+        logger(LOG_INFO, "OpenLI: SSL CA cert loading {%s} failed", cacertfile);
+        SSL_CTX_free(ctx);
+        return NULL;
+    }
+
+    //enforce cheking of client/server 
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+
+    if (SSL_CTX_use_certificate_file(ctx, certfile, SSL_FILETYPE_PEM) != 1){
+        logger(LOG_INFO, "OpenLI: SSL cert loading {%s} failed", certfile);
+        SSL_CTX_free(ctx);
+        return NULL;
+    }
+
+    if (SSL_CTX_use_PrivateKey_file(ctx, keyfile, SSL_FILETYPE_PEM) != 1){
+        logger(LOG_INFO, "OpenLI: SSL Key loading {%s} failed", keyfile);
+        SSL_CTX_free(ctx);
+        return NULL;
+    }
+
+    /* Make sure the key and certificate file match. */
+    if (SSL_CTX_check_private_key(ctx) != 1){
+        logger(LOG_INFO, "OpenLI: SSL CTX private key failed, %s and %s do not match", keyfile, certfile);
+        SSL_CTX_free(ctx);
+        return NULL;
+    }
+
+    logger(LOG_DEBUG, "OpenLI: OpenSSL CTX initlized, TLS encryption enabled.");
+    logger(LOG_DEBUG, "OpenLI: Using %s, %s and %s.", certfile, keyfile, cacertfile);
+
+    return ctx;
 }
 
 static inline int extend_net_buffer(net_buffer_t *nb, int musthave) {
@@ -940,7 +1041,13 @@ int transmit_net_buffer(net_buffer_t *nb, openli_proto_msgtype_t *err) {
     }
 
     //dump_buffer_contents(nb->actptr, NETBUF_CONTENT_SIZE(nb));
-    ret = send(nb->fd, nb->actptr, NETBUF_CONTENT_SIZE(nb), MSG_DONTWAIT);
+
+    if (nb->ssl != NULL){
+        ret = SSL_write(nb->ssl, nb->actptr, NETBUF_CONTENT_SIZE(nb));
+    }
+    else {
+        ret = send(nb->fd, nb->actptr, NETBUF_CONTENT_SIZE(nb), MSG_DONTWAIT);
+    }
 
     if (ret == -1) {
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
@@ -1513,7 +1620,13 @@ openli_proto_msgtype_t receive_net_buffer(net_buffer_t *nb, uint8_t **msgbody,
         }
     }
 
-    ret = recv(nb->fd, nb->appendptr, NETBUF_SPACE_REM(nb), MSG_DONTWAIT);
+    if (nb->ssl != NULL){
+        ret = SSL_read(nb->ssl, nb->appendptr, NETBUF_SPACE_REM(nb));
+    }
+    else {
+        ret = recv(nb->fd, nb->appendptr, NETBUF_SPACE_REM(nb), MSG_DONTWAIT);
+    }
+    
     if (ret <= 0) {
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
             return OPENLI_PROTO_NO_MESSAGE;

--- a/src/netcomms.h
+++ b/src/netcomms.h
@@ -29,6 +29,9 @@
 
 #include "config.h"
 #include <inttypes.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <fcntl.h>
 
 #define NETBUF_ALLOC_SIZE (10 * 1024 * 1024)
 
@@ -106,6 +109,7 @@ typedef struct net_buffer {
     char *actptr;
     int alloced;
     net_buffer_type_t buftype;
+    SSL *ssl;
 } net_buffer_t;
 
 typedef enum {
@@ -137,8 +141,11 @@ typedef enum {
     OPENLI_PROTO_FIELD_INTOPTIONS,
 } openli_proto_fieldtype_t;
 
-
-net_buffer_t *create_net_buffer(net_buffer_type_t buftype, int fd);
+void dump_cert_info(SSL *ssl);
+net_buffer_t *create_net_buffer(net_buffer_type_t buftype, int fd, SSL *ssl);
+SSL_CTX *ssl_init(const char *cacertfile, const char *certfile, const char *keyfile);
+int fd_set_nonblock(int fd);
+int fd_set_block(int fd);
 void destroy_net_buffer(net_buffer_t *nb);
 
 int construct_netcomm_protocol_header(ii_header_t *hdr, uint32_t contentlen,

--- a/src/provisioner/provisioner.c
+++ b/src/provisioner/provisioner.c
@@ -89,7 +89,7 @@ static inline int enable_epoll_write(provision_state_t *state,
 }
 
 static void create_socket_state(prov_epoll_ev_t *pev, int authtimerfd,
-        char *ipaddrstr, int isbad) {
+        char *ipaddrstr, int isbad, SSL *ssl) {
 
     prov_sock_state_t *cs = (prov_sock_state_t *)malloc(
             sizeof(prov_sock_state_t));
@@ -100,9 +100,10 @@ static void create_socket_state(prov_epoll_ev_t *pev, int authtimerfd,
         cs->log_allowed = 1;
     }
 
+    cs->ssl = ssl;
     cs->ipaddr = strdup(ipaddrstr);
-    cs->incoming = create_net_buffer(NETBUF_RECV, pev->fd);
-    cs->outgoing = create_net_buffer(NETBUF_SEND, pev->fd);
+    cs->incoming = create_net_buffer(NETBUF_RECV, pev->fd, cs->ssl);
+    cs->outgoing = create_net_buffer(NETBUF_SEND, pev->fd, cs->ssl);
     cs->trusted = 0;
     cs->halted = 0;
     cs->authfd = authtimerfd;
@@ -236,6 +237,10 @@ static int init_prov_state(provision_state_t *state, char *configfile) {
     state->pushport = NULL;
     state->pushaddr = NULL;
 
+    state->certfile = NULL;
+    state->keyfile = NULL;
+    state->cacertfile = NULL;
+
     state->badmediators = NULL;
     state->badcollectors = NULL;
 
@@ -270,6 +275,19 @@ static int init_prov_state(provision_state_t *state, char *configfile) {
     state->updatefd = NULL;
     state->mediatorfd = NULL;
     state->timerfd = NULL;
+
+    if (state->certfile && state->keyfile && state->cacertfile){
+        state->ctx = ssl_init(state->cacertfile, state->certfile, state->keyfile);
+    } else {
+        if (state->certfile || state->keyfile || state->cacertfile){
+            logger(LOG_INFO, "OpenLI: SSL error, missing keyfile or certfile names.");
+            return -1;
+        }
+        else{
+            logger(LOG_DEBUG, "OpenLI: Not using OpenSSL TLS connection.");
+            state->ctx = NULL;
+        }
+    }
 
     /* Use an fd to catch signals during our main epoll loop, so that we
      * can provide our own signal handling without causing epoll_wait to
@@ -393,6 +411,9 @@ static void free_all_mediators(prov_mediator_t **mediators) {
             close(med->authev->fd);
         }
         free(med->authev);
+        if(med->ssl){
+            SSL_free(med->ssl);
+        }
         free(med);
     }
 }
@@ -431,6 +452,9 @@ static void stop_all_collectors(prov_collector_t **collectors) {
         free(col->commev);
         if (col->authev->fd != -1) {
             close(col->authev->fd);
+        }
+        if (col->ssl){
+            SSL_free(col->ssl);
         }
         free(col->authev);
         free(col);
@@ -536,6 +560,9 @@ static void clear_prov_state(provision_state_t *state) {
     }
     if (state->mediateport) {
         free(state->mediateport);
+    }
+    if(state->ctx){
+        SSL_CTX_free(state->ctx);
     }
 
 }
@@ -931,6 +958,36 @@ static int receive_mediator(provision_state_t *state, prov_epoll_ev_t *pev) {
     return 0;
 }
 
+static int continue_handshake(provision_state_t *state, prov_epoll_ev_t *pev) {
+    prov_sock_state_t *cs = (prov_sock_state_t *)(pev->state);
+
+    int ret = SSL_accept(cs->ssl); //either keep running handshake or return when error 
+
+
+    if (ret <= 0){
+        ret = SSL_get_error(cs->ssl, ret);
+        if(ret == SSL_ERROR_WANT_READ || ret == SSL_ERROR_WANT_WRITE){
+            //keep trying
+            return 0;
+        }
+        else {
+            //fail out
+            logger(LOG_INFO, "OpenLI: SSL Handshake failed");
+            return -1;
+        }
+    }
+    logger(LOG_DEBUG, "OpenLI: SSL Handshake accepted");
+    dump_cert_info(cs->ssl);
+
+    //handshake has finished
+    if(pev->fdtype == PROV_EPOLL_MEDIATOR_HANDSHAKE ){
+        pev->fdtype = PROV_EPOLL_MEDIATOR;
+    }
+    else if(pev->fdtype == PROV_EPOLL_COLLECTOR_HANDSHAKE ){
+        pev->fdtype = PROV_EPOLL_COLLECTOR;
+    }
+}
+
 static int transmit_socket(provision_state_t *state, prov_epoll_ev_t *pev) {
 
     int ret;
@@ -1062,6 +1119,7 @@ static int accept_collector(provision_state_t *state) {
     col = calloc(1, sizeof(prov_collector_t));
 
     newfd = accept(state->clientfd->fd, (struct sockaddr *)&saddr, &socklen);
+    fd_set_nonblock(newfd);
 
     if (getnameinfo((struct sockaddr *)&saddr, socklen, strbuf, sizeof(strbuf),
             0, 0, NI_NUMERICHOST) != 0) {
@@ -1070,10 +1128,46 @@ static int accept_collector(provision_state_t *state) {
     }
 
     if (newfd >= 0) {
+
         col->commev = (prov_epoll_ev_t *)malloc(sizeof(prov_epoll_ev_t));
         col->authev = (prov_epoll_ev_t *)malloc(sizeof(prov_epoll_ev_t));
 
-        col->commev->fdtype = PROV_EPOLL_COLLECTOR;
+        if (state->ctx != NULL){ //only use TLS if ctx is set
+
+            col->ssl = SSL_new(state->ctx);
+            SSL_set_fd(col->ssl, newfd);
+
+            int errr = SSL_accept(col->ssl);
+
+            if(errr <= 0){
+                errr = SSL_get_error(col->ssl, errr);
+
+                if (errr != SSL_ERROR_WANT_WRITE &&
+                    errr != SSL_ERROR_WANT_READ && 
+                    errr != SSL_ERROR_WANT_ACCEPT &&
+                    errr != SSL_ERROR_WANT_CONNECT){ //handshake failed badly
+                    ERR_print_errors_fp(stderr);
+                    close(newfd);
+                    SSL_free(col->ssl);
+                    free(col->commev);
+                    free(col->authev);
+                    free(col);
+                    logger(LOG_INFO, "OpenLI: SSL Handshake failed %d", errr);
+                    return -1;
+                }
+                logger(LOG_DEBUG, "OpenLI: SSL Handshake started");
+                col->commev->fdtype = PROV_EPOLL_COLLECTOR_HANDSHAKE;
+            }
+            else {
+                logger(LOG_DEBUG, "OpenLI: SSL Handshake finished");
+                col->commev->fdtype = PROV_EPOLL_COLLECTOR;
+            }
+        } else {
+            col->ssl = NULL;
+            col->commev->fdtype = PROV_EPOLL_COLLECTOR;
+        }
+
+
         col->commev->fd = newfd;
         col->commev->state = NULL;
 
@@ -1088,9 +1182,9 @@ static int accept_collector(provision_state_t *state) {
         }
 
         if (bad == NULL) {
-            create_socket_state(col->commev, col->authev->fd, strbuf, 0);
+            create_socket_state(col->commev, col->authev->fd, strbuf, 0, col->ssl);
         } else {
-            create_socket_state(col->commev, col->authev->fd, strbuf, 1);
+            create_socket_state(col->commev, col->authev->fd, strbuf, 1, col->ssl);
         }
 
         col->authev->state = col->commev->state;
@@ -1135,6 +1229,7 @@ static int accept_mediator(provision_state_t *state) {
      * mediator, as well as any intercept->LEA mappings that we have.
      */
     newfd = accept(state->mediatorfd->fd, (struct sockaddr *)&saddr, &socklen);
+    fd_set_nonblock(newfd);
 
     if (getnameinfo((struct sockaddr *)&saddr, socklen, strbuf, sizeof(strbuf),
                 0, 0, NI_NUMERICHOST) != 0) {
@@ -1143,12 +1238,52 @@ static int accept_mediator(provision_state_t *state) {
     }
 
     if (newfd >= 0) {
+
         med = calloc(1, sizeof(prov_mediator_t));
-        med->fd = newfd;
-        med->details = NULL;     /* will receive this from mediator soon */
         med->commev = (prov_epoll_ev_t *)malloc(sizeof(prov_epoll_ev_t));
 
-        med->commev->fdtype = PROV_EPOLL_MEDIATOR;
+        if (state->ctx != NULL){ //only use TLS if ctx is set
+
+            med->ssl = SSL_new(state->ctx);
+            SSL_set_fd(med->ssl, newfd);
+
+            int errr = SSL_accept(med->ssl);
+            
+
+            if(errr <= 0){
+                errr = SSL_get_error(med->ssl, errr);
+
+                if (errr != SSL_ERROR_WANT_WRITE &&
+                    errr != SSL_ERROR_WANT_READ && 
+                    errr != SSL_ERROR_WANT_ACCEPT &&
+                    errr != SSL_ERROR_WANT_CONNECT){ //handshake failed badly
+                    ERR_print_errors_fp(stderr);
+                    close(newfd);
+                    SSL_free(med->ssl);
+                    free(med->commev);
+                    free(med);
+                    logger(LOG_INFO, "OpenLI: SSL Handshake failed %d", errr);
+                    return -1;
+                }
+                else{
+                    logger(LOG_DEBUG, "OpenLI: SSL Handshake started");
+                    med->commev->fdtype = PROV_EPOLL_MEDIATOR_HANDSHAKE;
+                }
+            }
+            else{
+                logger(LOG_DEBUG, "OpenLI: SSL Handshake finished");
+                med->commev->fdtype = PROV_EPOLL_MEDIATOR;
+            }
+            
+        } else {
+            med->ssl = NULL;
+            med->commev->fdtype = PROV_EPOLL_MEDIATOR;
+        }
+
+        
+        med->fd = newfd;
+        med->details = NULL;     /* will receive this from mediator soon */
+
         med->commev->fd = newfd;
         med->commev->state = NULL;
 
@@ -1166,9 +1301,9 @@ static int accept_mediator(provision_state_t *state) {
         }
 
         if (bad == NULL) {
-            create_socket_state(med->commev, med->authev->fd, strbuf, 0);
+            create_socket_state(med->commev, med->authev->fd, strbuf, 0, med->ssl);
         } else {
-            create_socket_state(med->commev, med->authev->fd, strbuf, 1);
+            create_socket_state(med->commev, med->authev->fd, strbuf, 1, med->ssl);
         }
         med->authev->state = med->commev->state;
 
@@ -1416,6 +1551,23 @@ static int check_epoll_fd(provision_state_t *state, struct epoll_event *ev) {
                 return -1;
             }
             break;
+
+        case PROV_EPOLL_MEDIATOR_HANDSHAKE: {
+                //continue handshake process
+                ret = continue_handshake(state, pev);
+                if (ret == -1) {
+                    drop_mediator(state, pev);
+                }
+            }
+            break;
+        case PROV_EPOLL_COLLECTOR_HANDSHAKE: {
+                //continue handshake process
+                ret = continue_handshake(state, pev);
+                if (ret == -1) {
+                    drop_collector(state, pev);
+                }
+            }
+            break; 
 
         case PROV_EPOLL_MEDIATOR:
             if (ev->events & EPOLLRDHUP) {
@@ -2611,7 +2763,7 @@ static void run(provision_state_t *state) {
 
 static void usage(char *prog) {
     fprintf(stderr, "Usage: %s [ -d ] -c configfile\n", prog);
-    fprintf(stderr, "\nSet the -d flag to run this program as a daemon.");
+    fprintf(stderr, "\nSet the -d flag to run this program as a daemon.\n");
 }
 
 int main(int argc, char *argv[]) {

--- a/src/provisioner/provisioner.h
+++ b/src/provisioner/provisioner.h
@@ -31,6 +31,10 @@
 #include <uthash.h>
 #include "netcomms.h"
 
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+
 typedef struct prov_epoll_ev {
     int fdtype;
     int fd;
@@ -47,6 +51,8 @@ enum {
     PROV_EPOLL_MAIN_TIMER,
     PROV_EPOLL_FD_TIMER,
     PROV_EPOLL_SIGNAL,
+    PROV_EPOLL_MEDIATOR_HANDSHAKE,
+    PROV_EPOLL_COLLECTOR_HANDSHAKE,
 };
 
 typedef struct update_state {
@@ -80,6 +86,7 @@ typedef struct prov_collector {
 
     prov_epoll_ev_t *commev;
     prov_epoll_ev_t *authev;
+    SSL *ssl;
 
     UT_hash_handle hh;
 } prov_collector_t;
@@ -90,6 +97,7 @@ typedef struct prov_mediator {
     openli_mediator_t *details;
     prov_epoll_ev_t *commev;
     prov_epoll_ev_t *authev;
+    SSL *ssl;
 
     UT_hash_handle hh;
 } prov_mediator_t;
@@ -103,6 +111,9 @@ typedef struct prov_state {
     char *mediateport;
     char *pushaddr;
     char *pushport;
+    char *certfile;
+    char *keyfile;
+    char *cacertfile;
 
     int epoll_fd;
     prov_mediator_t *mediators;
@@ -126,6 +137,7 @@ typedef struct prov_state {
     liid_hash_t *liid_map;
 
     int ignorertpcomfort;
+    SSL_CTX *ctx;
     /*
     int activeupdatefd;
     int updatetimerfd;
@@ -145,7 +157,8 @@ typedef struct prov_sock_state {
     int mainfd;
     int authfd;
     int clientrole;
-
+    SSL *ssl;
+    
 } prov_sock_state_t;
 
 #endif

--- a/sslgen.conf
+++ b/sslgen.conf
@@ -1,0 +1,15 @@
+[req]
+prompt = no
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+
+[req_distinguished_name]
+C = NZ
+ST = Waikato
+L = Hamilton
+O = WAND OpenLI
+CN = openli.nz
+
+[v3_req]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment

--- a/systemd/openli-collector.service
+++ b/systemd/openli-collector.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenLI collector daemon
+Documentation=http://github.com/wanduow/openli/wiki
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/openlicollector -c /etc/openli/collector-config.yaml
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/openli-mediator.service
+++ b/systemd/openli-mediator.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenLI mediator daemon
+Documentation=http://github.com/wanduow/openli/wiki
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/openlimediator -c /etc/openli/mediator-config.yaml
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/openli-provisioner.service
+++ b/systemd/openli-provisioner.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenLI provisioner daemon
+Documentation=http://github.com/wanduow/openli/wiki
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/openliprovisioner -c /etc/openli/provisioner-config.yaml
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Intended to resolve #10 

Also included in this PR:
 * spec files to build RPMs for Fedora and Centos 7
 * fixed bug where the collector forwarder thread would reset its expected sequence number for active VOIP intercepts after a provisioner restart, causing all subsequent packets for those intercepts to never be forwarded to the mediator.
 * build packages for Ubuntu disco