### PR TITLE
Tidy up IP intercept configuration

### DIFF
--- a/doc/ProvisionerDoc.md
+++ b/doc/ProvisionerDoc.md
@@ -82,11 +82,12 @@ intercept must be configured with the following parameters:
   of the agencies specified elsewhere in this configuration file).
 * Access type -- the technology used to provide the target with Internet
   access (e.g. DSL, Fiber, Wireless, etc).
+* User -- the username assigned to that user within your AAA system. This is
+  required, even if the target is only using static IP addresses.
 
-An IP intercept must also include ONE of the following parameters, which is
+An IP intercept may also include ONE of the following parameters, which is
 used to identify the intercept target.
 
-* User -- the username assigned to that user within your AAA system.
 * ALU Shim ID -- if you are using OpenLI to convert Alcatel-Lucent intercepts
   to ETSI-compliant records, this is the value that will be in the intercept-id
   fields of the packets emitted by the mirror.
@@ -97,11 +98,11 @@ used to identify the intercept target.
 * Static IPs -- if the target has a static IP (range), you can use this
   parameter to tell OpenLI which IPs belong to the target.
 
-If you are using User as the target identification method, you will need to
-ensure that the OpenLI collectors receive a copy of all RADIUS traffic
-relating to the subscribers whose traffic will be passing that collector.
-This includes both Authentication AND Accounting messages, as well both the
-Requests and Responses for both message types.
+If you are relying solely on the User as the target identification method, you
+will need to ensure that the OpenLI collectors receive a copy of all RADIUS
+traffic relating to the subscribers whose IP traffic will be passing that
+collector. This includes both Authentication AND Accounting messages, as well
+both the Requests and Responses for both message types.
 
 If you are using the ALU Shim or JMirror methods, you will still need to provide
 a RADIUS feed to an OpenLI collector to generate the IRI records but the
@@ -244,14 +245,6 @@ An IP intercept must contain the following key-value elements:
 * authcountrycode       -- the authorisation country code
 * deliverycountrycode   -- the delivery country code
 * user                  -- the AAA username for the target
-* vendmirrorid          -- if using a vendor mirroring platform to stream
-                           packets to the collector, this is the intercept ID
-                           that you have assigned to the packets on the
-                           mirroring platform for the target user.
-                           (only for re-encoding ALU or JMirror intercepts as
-                           ETSI)
-* staticips             -- a list of IP ranges that are known to have been
-                           assigned to the target.
 * mediator              -- the ID of the mediator which will forward the
                            intercept
 * agencyid              -- the internal identifier of the agency that requested
@@ -263,6 +256,16 @@ Valid access types are:
   'dialup', 'adsl', 'vdsl', 'fiber', 'wireless', 'lan', 'satellite', 'wimax',
   'cable' and 'wireless-other'.
 
+Optional key-value elements for an IP intercept are:
+
+* vendmirrorid          -- if using a vendor mirroring platform to stream
+                           packets to the collector, this is the intercept ID
+                           that you have assigned to the packets on the
+                           mirroring platform for the target user.
+                           (only for re-encoding ALU or JMirror intercepts as
+                           ETSI)
+* staticips             -- a list of IP ranges that are known to have been
+                           assigned to the target.
 
 `staticips:` are expressed as a YAML list: one list item per IP range that
 is associated with the target. Each list item is a YAML map containing the

--- a/doc/exampleconfigs/provisioner-example.yaml
+++ b/doc/exampleconfigs/provisioner-example.yaml
@@ -80,10 +80,14 @@ ipintercepts:
 # an ETSI-compliant one. All ALU intercept packets with an
 # Intercept ID of 522781 will be converted to have the ETSI LIID of NAPP9321HN
 # and the resulting records will be forwarded to the "Spooks" agency.
+# Note that we still require a 'user' parameter to be set -- this is to
+# ensure that any relevant AAA traffic for that user which is seen by the
+# collector is properly intercepted and exported via HI2.
 
  - liid: NAPP9321HN             # LIID, should be provided by requesting agency
    authcountrycode: NZ          # Authorisation country code
    deliverycountrycode: NZ      # Delivery country code
+   user: "lexluthor"            # Username identifying the target in your AAA
    vendmirrorid: 522781         # Intercept-ID number used by the ALU
                                 # intercept.
    mediator: 6001               # ID of the mediator to send intercept via
@@ -99,6 +103,7 @@ ipintercepts:
  - liid: GTNF4221AU             # LIID, should be provided by requesting agency
    authcountrycode: NZ          # Authorisation country code
    deliverycountrycode: NZ      # Delivery country code
+   user: "skeletor"             # Username identifying the target in your AAA
    vendmirrorid: 0x12121212     # Intercept ID number used by the Juniper
                                 # mirroring.
    mediator: 6001               # ID of the mediator to send intercept via
@@ -116,6 +121,10 @@ ipintercepts:
 # they are part of the same communication session; this is probably what you
 # want in most circumstances.
 #
+# Once again, a user name is required when specifying the intercept
+# even though this target will probably not appear in any AAA traffic seen
+# by the collector.
+#
 # If, during the course of an intercept, the IP ranges assigned to the
 # target are modified somehow, you should change the session ID and tell
 # the provisioner to reload its configuration (even for IP ranges that remain
@@ -130,6 +139,7 @@ ipintercepts:
    authcountrycode: NZ          # Authorisation country code
    deliverycountrycode: NZ      # Delivery country code
    mediator: 6001               # ID of the mediator to send intercept via
+   user: "edwardnigma"          # Username for the target
    agencyid: "Police"           # ID of agency to send intercept to
    accesstype: "LAN"            # Access tech used by the target to access IP
    staticips:

--- a/src/collector/collector_sync.c
+++ b/src/collector/collector_sync.c
@@ -995,17 +995,6 @@ static int new_ipintercept(collector_sync_t *sync, uint8_t *intmsg,
     HASH_FIND(hh_liid, sync->ipintercepts, cept->common.liid,
             cept->common.liid_len, x);
 
-    /* TODO change alushimid and username to not be mutually exclusive.
-     * Ideally, username would be mandatory even for ALU intercepts as we
-     * still will need to produce IRIs for those targets from AAA traffic.
-     * We can also use the AAA stream to assign CINs for the CCs created from
-     * the ALU intercepted packets, so really this still needs a lot of proper
-     * sync work.
-     *
-     * Therefore, we'll want to only announce ALU Shim IDs once we have a
-     * valid session for the user and withdraw them once the session is over.
-     */
-
     if (x) {
         /* Duplicate LIID */
 
@@ -1063,8 +1052,9 @@ static int new_ipintercept(collector_sync_t *sync, uint8_t *intmsg,
 
     if (cept->vendmirrorid != OPENLI_VENDOR_MIRROR_NONE) {
         logger(LOG_INFO,
-                "OpenLI: received IP intercept from provisioner for Vendor Mirrored ID %u (LIID %s, authCC %s)",
-                cept->vendmirrorid, cept->common.liid, cept->common.authcc);
+                "OpenLI: received IP intercept from provisioner for Vendor Mirrored ID %u (LIID %s, authCC %s), target is %s",
+                cept->vendmirrorid, cept->common.liid, cept->common.authcc,
+                cept->username ? cept->username : "unknown");
 
         /* Don't need to wait for a session to start an ALU intercept.
          * The CIN is contained within the packet and only valid

--- a/src/configparser.c
+++ b/src/configparser.c
@@ -751,7 +751,7 @@ static int parse_ipintercept_list(ipintercept_t **ipints, yaml_document_t *doc,
                     newcept->common.liid_len, newcept);
 
             if (newcept->username && newcept->statics) {
-                logger(LOG_INFO, "OpenLI: IP intercept %s specifies both a username and a set of static IPs -- is this intentional?");
+                logger(LOG_INFO, "OpenLI: IP intercept %s specifies both a username and a set of static IPs -- is this intentional?", newcept->common.liid);
             }
         } else {
             logger(LOG_INFO, "OpenLI: IP Intercept configuration was incomplete -- skipping.");

--- a/src/configparser.c
+++ b/src/configparser.c
@@ -742,18 +742,15 @@ static int parse_ipintercept_list(ipintercept_t **ipints, yaml_document_t *doc,
 
         if (newcept->common.liid != NULL && newcept->common.authcc != NULL &&
                 newcept->common.delivcc != NULL &&
-                (newcept->username != NULL ||
-                 newcept->vendmirrorid != OPENLI_VENDOR_MIRROR_NONE ||
-                 newcept->statics != NULL) &&
+                newcept->username != NULL &&
                 newcept->common.destid > 0 &&
                 newcept->common.targetagency != NULL) {
             HASH_ADD_KEYPTR(hh_liid, *ipints, newcept->common.liid,
                     newcept->common.liid_len, newcept);
-
-            if (newcept->username && newcept->statics) {
-                logger(LOG_INFO, "OpenLI: IP intercept %s specifies both a username and a set of static IPs -- is this intentional?", newcept->common.liid);
-            }
         } else {
+            if (newcept->username == NULL) {
+                logger(LOG_INFO, "OpenLI: provisioner configuration error: 'user' must be specified for an IP intercept");
+            }
             logger(LOG_INFO, "OpenLI: IP Intercept configuration was incomplete -- skipping.");
         }
     }

--- a/src/netcomms.h
+++ b/src/netcomms.h
@@ -100,6 +100,7 @@ typedef enum {
     OPENLI_PROTO_REMOVE_STATICIPS,
     OPENLI_PROTO_MODIFY_VOIPINTERCEPT,
     OPENLI_PROTO_CONFIG_RELOADED,
+    OPENLI_PROTO_MODIFY_IPINTERCEPT,
 } openli_proto_msgtype_t;
 
 typedef struct net_buffer {
@@ -196,6 +197,8 @@ int decode_mediator_withdraw(uint8_t *msgbody, uint16_t len,
 int decode_ipintercept_start(uint8_t *msgbody, uint16_t len,
         ipintercept_t *ipint);
 int decode_ipintercept_halt(uint8_t *msgbody, uint16_t len,
+        ipintercept_t *ipint);
+int decode_ipintercept_modify(uint8_t *msgbody, uint16_t len,
         ipintercept_t *ipint);
 int decode_voipintercept_start(uint8_t *msgbody, uint16_t len,
         voipintercept_t *vint);


### PR DESCRIPTION
Previous IP intercept configuration code had made some flawed assumptions that were not working well in practice, e.g. treating vendor mirror interception IDs as being mutually exclusive with RADIUS usernames.

Primary changes:
 * ALL IP intercepts must provide a `user` as part of their configuration, which is used to identify appropriate RADIUS messages for IRI generation, regardless of whether that user's CCs are going to be delivered via standard IP capture or via one of the vendor mirroring methods (Jmirror, ALU shim, etc).
 * Fixed a number of inconsistent behaviours when re-configuring an existing IP intercept, especially w.r.t changing either the `user` or `vendmirrorid` attributes. Modifying an IP intercept in any way will no longer automatically delete and then re-create the intercept on the collectors -- the intercept is not interrupted (if at all possible).