### PR TITLE
Fix segfault when reassembling UDP SIP fragments

### DIFF
--- a/src/collector/collector_sync_voip.c
+++ b/src/collector/collector_sync_voip.c
@@ -281,7 +281,6 @@ static int update_rtp_stream(collector_sync_voip_t *sync, rtpstreaminf_t *rtp,
     uint32_t port;
     struct sockaddr_storage *saddr;
     int family, i;
-    int updaterequired = 1;
     sync_sendq_t *sendq, *tmp;
 
     errno = 0;
@@ -321,9 +320,6 @@ static int update_rtp_stream(collector_sync_voip_t *sync, rtpstreaminf_t *rtp,
         return 0;
     }
 
-    if (!updaterequired) {
-        return 0;
-    }
     /* If we get here, we need to push the RTP stream details to the
      * processing threads. */
     HASH_ITER(hh, (sync_sendq_t *)(sync->glob->collector_queues), sendq, tmp) {

--- a/src/collector/sipparsing.c
+++ b/src/collector/sipparsing.c
@@ -250,6 +250,7 @@ static int _add_sip_fragment(openli_sip_parser_t *p,
             free(p->sipmessage);
         }
         p->sipmessage = completefrag;
+        p->sipalloced = 1;
         p->siplen = fraglen - sizeof(libtrace_udp_t);
         p->sipoffset = sizeof(libtrace_udp_t);
         return SIP_ACTION_REASSEMBLE_IPFRAG;
@@ -280,6 +281,7 @@ static int _add_sip_fragment(openli_sip_parser_t *p,
             free(p->sipmessage);
         }
         p->sipmessage = (char *)tcp;
+        p->sipalloced = 1;
         p->siplen = fraglen - (tcp->doff * 4);
         p->sipoffset = (tcp->doff * 4);
         return SIP_ACTION_REASSEMBLE_IPFRAG;
@@ -292,7 +294,6 @@ static int _add_sip_fragment(openli_sip_parser_t *p,
 int add_sip_packet_to_parser(openli_sip_parser_t **parser,
         libtrace_packet_t *packet, uint8_t logallowed) {
 
-    void *transport;
     char *completefrag = NULL;
     uint8_t proto, moreflag, isfrag;
     uint32_t rem, plen;
@@ -370,7 +371,6 @@ int add_sip_packet_to_parser(openli_sip_parser_t **parser,
             }
             /* complete fragment in completefrag */
             isfrag = 1;
-            transport = completefrag;
         }
     }
 

--- a/src/provisioner/provisioner.h
+++ b/src/provisioner/provisioner.h
@@ -169,13 +169,20 @@ typedef struct prov_mediator {
 } prov_mediator_t;
 
 typedef struct prov_intercept_conf {
+    /** The set of known RADIUS servers that will be provided to collectors */
     coreserver_t *radiusservers;
+    /** The set of known SIP servers that will be provided to collectors */
     coreserver_t *sipservers;
+    /** The set of VOIP intercepts that we are currently running */
     voipintercept_t *voipintercepts;
+    /** The set of IP intercepts that we are currently running */
     ipintercept_t *ipintercepts;
+    /** The set of LEAs that are potential intercept recipients */
     prov_agency_t *leas;
+    /** A map of LIIDs to their destination LEAs */
     liid_hash_t *liid_map;
 
+    /** A mutex to protect the intercept config from race conditions */
     pthread_mutex_t safelock;
 } prov_intercept_conf_t;
 
@@ -208,16 +215,6 @@ typedef struct prov_state {
     /** The set of collectors that we are managing */
     prov_collector_t *collectors;
 
-    /** The set of known RADIUS servers that will be provided to collectors */
-    coreserver_t *radiusservers;
-    /** The set of known SIP servers that will be provided to collectors */
-    coreserver_t *sipservers;
-
-    /** The set of VOIP intercepts that we are currently running */
-    voipintercept_t *voipintercepts;
-    /** The set of IP intercepts that we are currently running */
-    ipintercept_t *ipintercepts;
-
     /** Epoll event for the collector connection socket */
     prov_epoll_ev_t *clientfd;
     /** Epoll event for the updater connection socket */
@@ -232,12 +229,6 @@ typedef struct prov_state {
     prov_intercept_conf_t interceptconf;
     struct MHD_Daemon *updatedaemon;
     MHD_socket updatesockfd;
-
-    /** The set of LEAs that are potential intercept recipients */
-    prov_agency_t *leas;
-
-    /** A map of LIIDs to their destination LEAs */
-    liid_hash_t *liid_map;
 
     /** A flag indicating whether collectors should ignore RTP comfort noise
      *  packets when intercepting voice traffic.


### PR DESCRIPTION
Other fixes include:
 * fix minor memory leak when adding new coreservers via the provisioner REST API
 * various code tidy ups (removing unused variables etc).