### PR TITLE
IPIRI BER encoding

### DIFF
--- a/src/collector/collector_seqtracker.c
+++ b/src/collector/collector_seqtracker.c
@@ -221,8 +221,9 @@ static void track_new_intercept(seqtracker_thread_data_t *seqdata,
         intstate->preencoded_ber = calloc(WANDDER_PREENCODE_LAST, sizeof intstate->preencoded_ber);
         wandder_etsili_preencode_static_fields_ber(intstate->preencoded_ber, (wandder_etsili_intercept_details_t*)&intdetails);
         
-        intstate->top = calloc(sizeof *intstate->top,1);
-        wandder_init_pshdr_ber(intstate->preencoded_ber, intstate->top);
+        //intstate->top = calloc(sizeof *intstate->top,1);
+        //wandder_init_pshdr_ber(intstate->preencoded_ber, intstate->top);
+        //this should be done inside calls to libwandder, not here
 #endif
     }
 }
@@ -343,23 +344,24 @@ static int run_encoding_job(seqtracker_thread_data_t *seqdata,
     job.preencoded_ber = intstate->preencoded_ber;
     //create new copy of top so differnt encoding jobs dont share 
     //workspaces, (encoding is filling in the missing parts of top)
-    if(intstate->top){
-        wandder_etsili_top_t* top = malloc(sizeof *top);
-        memcpy(top, intstate->top, sizeof *top);
-        top->len = intstate->top->len;
-        top->alloc_len = intstate->top->len;
-        top->buf = malloc(intstate->top->len);
-        memcpy(top->buf, intstate->top->buf, intstate->top->len);
-        ptrdiff_t offset = (top->buf - intstate->top->buf);
-        top->header.cin    += offset;
-        top->header.seqno  += offset;
-        top->header.sec    += offset;
-        top->header.usec   += offset;
-        top->header.end    += offset;
-        top->body.ipcc.dir    += offset;
-        top->body.ipcc.ipcontent   += offset;
-        job.top = top;
-    }
+    // if(job.preencoded_ber) {
+    //     wandder_etsili_top_t* top = malloc(sizeof *top);
+    //     memcpy(top, intstate->top, sizeof *top);
+    //     top->len = intstate->top->len;
+    //     top->alloc_len = intstate->top->len;
+    //     top->buf = malloc(intstate->top->len);
+    //     memcpy(top->buf, intstate->top->buf, intstate->top->len);
+    //     ptrdiff_t offset = (top->buf - intstate->top->buf);
+    //     top->header.cin    += offset;
+    //     top->header.seqno  += offset;
+    //     top->header.sec    += offset;
+    //     top->header.usec   += offset;
+    //     top->header.end    += offset;
+    //     top->body.ipcc.dir    += offset;
+    //     top->body.ipcc.ipcontent   += offset;
+    //     job.top = top;
+    // } 
+    //this hould be done inside calls to libwandder, not her
 #endif
 	job.origreq = recvd;
 	job.liid = strdup(liid);

--- a/src/collector/collector_seqtracker.c
+++ b/src/collector/collector_seqtracker.c
@@ -342,26 +342,6 @@ static int run_encoding_job(seqtracker_thread_data_t *seqdata,
 
 #ifdef HAVE_BER_ENCODING
     job.preencoded_ber = intstate->preencoded_ber;
-    //create new copy of top so differnt encoding jobs dont share 
-    //workspaces, (encoding is filling in the missing parts of top)
-    // if(job.preencoded_ber) {
-    //     wandder_etsili_top_t* top = malloc(sizeof *top);
-    //     memcpy(top, intstate->top, sizeof *top);
-    //     top->len = intstate->top->len;
-    //     top->alloc_len = intstate->top->len;
-    //     top->buf = malloc(intstate->top->len);
-    //     memcpy(top->buf, intstate->top->buf, intstate->top->len);
-    //     ptrdiff_t offset = (top->buf - intstate->top->buf);
-    //     top->header.cin    += offset;
-    //     top->header.seqno  += offset;
-    //     top->header.sec    += offset;
-    //     top->header.usec   += offset;
-    //     top->header.end    += offset;
-    //     top->body.ipcc.dir    += offset;
-    //     top->body.ipcc.ipcontent   += offset;
-    //     job.top = top;
-    // } 
-    //this hould be done inside calls to libwandder, not her
 #endif
 	job.origreq = recvd;
 	job.liid = strdup(liid);

--- a/src/collector/encoder_worker.c
+++ b/src/collector/encoder_worker.c
@@ -190,6 +190,9 @@ static int encode_etsi(openli_encoder_t *enc, openli_encoding_job_t *job,
 #ifdef HAVE_BER_ENCODING
      if (job->preencoded_ber != NULL) {
          isDer = 0;
+         if (job->top == NULL ){
+             job->top = calloc(sizeof(wandder_etsili_top_t), 1);
+         }
      }
 #endif
 
@@ -215,9 +218,10 @@ static int encode_etsi(openli_encoder_t *enc, openli_encoding_job_t *job,
 #ifdef HAVE_BER_ENCODING
             }
             else{
-                //TODO
-                logger(LOG_INFO, "OpenLI: BER encoding for IPIRI is not yet implemented.");
-                //complain loudly that this dont work yet
+                ret = encode_ipiri_ber(job->preencoded_ber,
+                        &(job->origreq->data.ipiri), enc->freegenerics,
+                        job->seqno, &(job->origreq->ts), res, job->top, 
+                        enc->encoder);
 #endif
             }
             break;

--- a/src/collector/ipiri.c
+++ b/src/collector/ipiri.c
@@ -64,15 +64,14 @@ int sort_generics(etsili_generic_t *a, etsili_generic_t *b) {
 }
 
 static inline void encode_ipiri_shared(wandder_encoder_t *encoder,
+        etsili_generic_freelist_t *freegenerics,
         openli_ipiri_job_t *job,
         etsili_iri_type_t *iritype_p,
-        etsili_generic_freelist_t *freegenerics,
         etsili_generic_t **params_p) {
 
-    etsili_generic_t *np;
-    etsili_ipaddress_t targetip;
-    etsili_generic_t *params = NULL;
+    etsili_generic_t *np, *params = NULL;
     etsili_iri_type_t iritype;
+    etsili_ipaddress_t targetip;
     int64_t ipversion = 0;
     params = job->customparams;
 
@@ -110,6 +109,7 @@ static inline void encode_ipiri_shared(wandder_encoder_t *encoder,
     } else {
         iritype = job->iritype;
     }
+
 
     np = create_etsili_generic(freegenerics,
             IPIRI_CONTENTS_INTERNET_ACCESS_TYPE, sizeof(uint32_t),
@@ -200,9 +200,9 @@ int encode_ipiri(wandder_encoder_t *encoder,
     uint32_t liidlen = precomputed[OPENLI_PREENCODE_LIID].vallen;
 
     encode_ipiri_shared(encoder,
+        freegenerics,
         job,
         &iritype,
-        freegenerics,
         &params);
 
     gettimeofday(&tv, NULL);
@@ -278,9 +278,9 @@ int encode_ipiri_ber(wandder_buf_t **preencoded_ber,
     uint32_t liidlen = (uint32_t)((size_t)preencoded_ber[WANDDER_PREENCODE_LIID_LEN]);
 
     encode_ipiri_shared(encoder,
+        freegenerics,
         job,
         &iritype,
-        freegenerics,
         &params);
 
     gettimeofday(&current_tv, NULL);

--- a/src/collector/ipiri.h
+++ b/src/collector/ipiri.h
@@ -138,6 +138,8 @@ int encode_ipiri(wandder_encoder_t *encoder,
         wandder_encode_job_t *precomputed,
         openli_ipiri_job_t *job, uint32_t seqno,
         openli_encoded_result_t *res);
+
+#ifdef HAVE_BER_ENCODING
 int encode_ipiri_ber(wandder_buf_t **preencoded_ber,
         openli_ipiri_job_t *job,
         etsili_generic_freelist_t *freegenerics,
@@ -145,6 +147,7 @@ int encode_ipiri_ber(wandder_buf_t **preencoded_ber,
         openli_encoded_result_t *res,
         wandder_etsili_top_t *top, 
         wandder_encoder_t *encoder);
+#endif
 
 /* TODO consider adding free lists to these APIs to avoid excess mallocs */
 int ipiri_create_id_printable(char *idstr, int length, ipiri_id_t *ipiriid);

--- a/src/collector/ipiri.h
+++ b/src/collector/ipiri.h
@@ -138,6 +138,13 @@ int encode_ipiri(wandder_encoder_t *encoder,
         wandder_encode_job_t *precomputed,
         openli_ipiri_job_t *job, uint32_t seqno,
         openli_encoded_result_t *res);
+int encode_ipiri_ber(wandder_buf_t **preencoded_ber,
+        openli_ipiri_job_t *job,
+        etsili_generic_freelist_t *freegenerics,
+        uint32_t seqno, struct timeval *tv,
+        openli_encoded_result_t *res,
+        wandder_etsili_top_t *top, 
+        wandder_encoder_t *encoder);
 
 /* TODO consider adding free lists to these APIs to avoid excess mallocs */
 int ipiri_create_id_printable(char *idstr, int length, ipiri_id_t *ipiriid);


### PR DESCRIPTION
Added IPIRI BER encoding from libwandder,
Moved initialization of BER encodings into libwandder, so that openli only needs to provide the encoding data and either an new empty encode struct or a previously used one.