### PR TITLE
Resolve GTP reordering issues, fix #43

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+openli (1.0.4-1~gtptest02) UNRELEASED; urgency=medium
+
+  * Pre-release packaging of 1.0.4 for Datora to use for testing the
+    new GTP-based mobile interception capabilities.
+  * Fixed issue where GTP sessions were not properly tracked if the request
+    and response were seen in the wrong order.
+
+ -- Shane Alcock <shane.alcock@waikato.ac.nz>  Mon, 9 Dec 2019 11:00:20 +1300
+
 openli (1.0.4-1~gtptest01) UNRELEASED; urgency=medium
 
   * Pre-release packaging of 1.0.4 for Datora to use for testing the

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,8 @@ openliprovisioner_SOURCES=provisioner/provisioner.c provisioner/provisioner.h \
                 provisioner/provisioner_client.h \
                 provisioner/configwriter.c provisioner/clientupdates.c \
                 provisioner/updateserver.h \
-                provisioner/updateserver_jsonparsing.c
+                provisioner/updateserver_jsonparsing.c \
+                provisioner/hup_reload.c
 
 openliprovisioner_LDFLAGS = -lpthread @PROVISIONER_LIBS@
 openliprovisioner_LDADD = @ADD_LIBS@

--- a/src/collector/accessplugins/gtp.c
+++ b/src/collector/accessplugins/gtp.c
@@ -1032,6 +1032,9 @@ static access_session_t *gtp_update_session_state(access_plugin_t *p,
             JLI(pval, glob->saved_packets, saved->reqid);
             *pval = (Word_t)saved;
 
+            if (check->ipcontent) {
+                free(check->ipcontent);
+            }
             gtp_free_ie_list(check->ies);
             free(check);
             return NULL;

--- a/src/collector/accessplugins/radius.c
+++ b/src/collector/accessplugins/radius.c
@@ -1914,6 +1914,15 @@ static uint32_t radius_get_packet_sequence(access_plugin_t *p,
     return DERIVE_REQUEST_ID(raddata, raddata->msgtype);
 }
 
+static uint8_t *radius_get_ip_contents(access_plugin_t *p, void *parseddata,
+        uint16_t *iplen, int iteration) {
+
+    /* TODO */
+
+    *iplen = 0;
+    return NULL;
+}
+
 static access_plugin_t radiusplugin = {
 
     "RADIUS",
@@ -1931,6 +1940,7 @@ static access_plugin_t radiusplugin = {
     //radius_create_iri_from_packet,
     radius_destroy_session_data,
     radius_get_packet_sequence,
+    radius_get_ip_contents,
 };
 
 access_plugin_t *get_radius_access_plugin(void) {

--- a/src/collector/internetaccess.h
+++ b/src/collector/internetaccess.h
@@ -119,7 +119,6 @@ struct internet_user {
     UT_hash_handle hh;
 };
 
-
 struct access_plugin {
     const char *name;
     uint8_t access_type;
@@ -156,6 +155,8 @@ struct access_plugin {
     void (*destroy_session_data)(access_plugin_t *p, access_session_t *sess);
 
     uint32_t (*get_packet_sequence)(access_plugin_t *p, void *parseddata);
+    uint8_t *(*get_ip_contents)(access_plugin_t *p, void *parseddata,
+            uint16_t *iplen, int iteration);
 
     /* APIs that are internally used but should be required by all plugins
      * so may as well enforce them as part of the plugin definition.

--- a/src/configparser.c
+++ b/src/configparser.c
@@ -220,7 +220,7 @@ static int parse_defradusers_list(prov_intercept_conf_t *state,
 
         defuser->name = strdup((char *)node->data.scalar.value);
         defuser->namelen = strlen(defuser->name);
-        defuser->awaitingconfirm = 0;
+        defuser->awaitingconfirm = 1;
 
         HASH_FIND(hh, state->defradusers, defuser->name, defuser->namelen,
                 found);

--- a/src/mediator/mediator.h
+++ b/src/mediator/mediator.h
@@ -122,6 +122,7 @@ typedef struct mediator_agency {
     char *agencyid;
     int awaitingconfirm;
     int disabled;
+    int disabled_msg;
     handover_t *hi2;
     handover_t *hi3;
 } mediator_agency_t;

--- a/src/provisioner/hup_reload.c
+++ b/src/provisioner/hup_reload.c
@@ -1,0 +1,761 @@
+/*
+ *
+ * Copyright (c) 2018 The University of Waikato, Hamilton, New Zealand.
+ * All rights reserved.
+ *
+ * This file is part of OpenLI.
+ *
+ * This code has been developed by the University of Waikato WAND
+ * research group. For further information please see http://www.wand.net.nz/
+ *
+ * OpenLI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenLI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+#include "provisioner.h"
+#include "logger.h"
+#include "util.h"
+#include "configparser.h"
+
+static inline int reload_staticips(provision_state_t *currstate,
+        ipintercept_t *ipint, ipintercept_t *newequiv) {
+
+    static_ipranges_t *ipr, *tmp, *found;
+
+    HASH_ITER(hh, ipint->statics, ipr, tmp) {
+        HASH_FIND(hh, newequiv->statics, ipr->rangestr, strlen(ipr->rangestr),
+                found);
+        if (!found || found->cin != ipr->cin) {
+            remove_existing_staticip_range(currstate, ipint, ipr);
+        } else {
+            found->awaitingconfirm = 0;
+        }
+    }
+
+    HASH_ITER(hh, newequiv->statics, ipr, tmp) {
+        if (ipr->awaitingconfirm == 0) {
+            continue;
+        }
+        add_new_staticip_range(currstate, ipint, ipr);
+    }
+
+    return 0;
+}
+
+static inline int ip_intercept_equal(ipintercept_t *a, ipintercept_t *b) {
+    if (strcmp(a->common.liid, b->common.liid) != 0) {
+        return 0;
+    }
+
+    if (strcmp(a->common.authcc, b->common.authcc) != 0) {
+        return 0;
+    }
+
+    if (strcmp(a->common.delivcc, b->common.delivcc) != 0) {
+        return 0;
+    }
+
+    if (a->username && b->username && strcmp(a->username, b->username) != 0) {
+        return 0;
+    }
+
+    if (a->vendmirrorid != b->vendmirrorid) {
+        return 0;
+    }
+
+    if (strcmp(a->common.targetagency, b->common.targetagency) != 0) {
+        return 0;
+    }
+
+    if (a->accesstype != b->accesstype) {
+        return 0;
+    }
+
+    return 1;
+}
+
+
+static int reload_intercept_config_filename(provision_state_t *currstate,
+        provision_state_t *newstate) {
+
+	if (newstate->interceptconffile == NULL) {
+		newstate->interceptconffile = strdup(DEFAULT_INTERCEPT_CONFIG_FILE);
+	}
+
+    if (strcmp(newstate->interceptconffile, currstate->interceptconffile)
+            != 0) {
+        logger(LOG_INFO,
+                "OpenLI: intercept configuration is now being read from %s.",
+                newstate->interceptconffile);
+        free(currstate->interceptconffile);
+        currstate->interceptconffile = newstate->interceptconffile;
+        newstate->interceptconffile = NULL;
+        return 1;
+    }
+    return 0;
+}
+
+static int reload_leas(provision_state_t *state, prov_intercept_conf_t *curr,
+        prov_intercept_conf_t *latest) {
+
+    prov_agency_t *lea, *tmp, *newequiv;
+
+    HASH_ITER(hh, curr->leas, lea, tmp) {
+        HASH_FIND_STR(latest->leas, lea->ag->agencyid, newequiv);
+
+        if (!newequiv) {
+            /* Agency has been withdrawn entirely */
+            withdraw_agency_from_mediators(state, lea);
+        } else if (agency_equal(lea->ag, newequiv->ag)) {
+            newequiv->announcereq = 0;
+        } else {
+            /* Agency has changed, withdraw current and announce new */
+            withdraw_agency_from_mediators(state, lea);
+            newequiv->announcereq = 1;
+        }
+    }
+
+    HASH_ITER(hh, latest->leas, lea, tmp) {
+        if (lea->announcereq) {
+            announce_lea_to_mediators(state, lea);
+            lea->announcereq = 0;
+        }
+    }
+
+    return 0;
+}
+
+static int reload_default_radius_users(provision_state_t *state,
+        default_radius_user_t *currusers, default_radius_user_t *newusers) {
+
+    default_radius_user_t *dru, *tmp, *newequiv;
+
+    HASH_ITER(hh, currusers, dru, tmp) {
+        HASH_FIND(hh, newusers, dru->name, dru->namelen, newequiv);
+        if (!newequiv) {
+            withdraw_default_radius_username(state, dru);
+        } else {
+            newequiv->awaitingconfirm = 0;
+        }
+    }
+
+    HASH_ITER(hh, newusers, dru, tmp) {
+        if (dru->awaitingconfirm) {
+            announce_default_radius_username(state, dru);
+        }
+    }
+
+    return 0;
+}
+
+static int reload_coreservers(provision_state_t *state, coreserver_t *currserv,
+        coreserver_t *newserv) {
+
+    coreserver_t *cs, *tmp, *newequiv;
+
+    HASH_ITER(hh, currserv, cs, tmp) {
+        HASH_FIND(hh, newserv, cs->serverkey, strlen(cs->serverkey), newequiv);
+        if (!newequiv) {
+            announce_coreserver_change(state, cs, false);
+        } else {
+            newequiv->awaitingconfirm = 0;
+        }
+    }
+
+    HASH_ITER(hh, newserv, cs, tmp) {
+        if (cs->awaitingconfirm) {
+            announce_coreserver_change(state, cs, true);
+        }
+    }
+    return 0;
+}
+
+static inline int compare_sip_targets(provision_state_t *currstate,
+        voipintercept_t *existing, voipintercept_t *reload) {
+
+    openli_sip_identity_t *oldtgt, *newtgt;
+    libtrace_list_node_t *n1, *n2;
+
+    /* Sluggish (n^2), but hopefully we don't have many IDs per intercept */
+
+    n1 = existing->targets->head;
+    while (n1) {
+        oldtgt = *((openli_sip_identity_t **)(n1->data));
+        n1 = n1->next;
+
+        oldtgt->awaitingconfirm = 1;
+        n2 = reload->targets->head;
+        while (n2) {
+            newtgt = *((openli_sip_identity_t **)(n2->data));
+            n2 = n2->next;
+            if (newtgt->awaitingconfirm == 0) {
+                continue;
+            }
+
+            if (are_sip_identities_same(newtgt, oldtgt)) {
+                oldtgt->awaitingconfirm = 0;
+                newtgt->awaitingconfirm = 0;
+                break;
+            }
+        }
+
+        if (oldtgt->awaitingconfirm) {
+            /* This target is no longer in the intercept config so
+             * withdraw it. */
+            if (announce_sip_target_change(currstate, oldtgt, existing, 0) < 0)
+            {
+                return -1;
+            }
+        }
+    }
+
+    n2 = reload->targets->head;
+    while (n2) {
+        newtgt = *((openli_sip_identity_t **)(n2->data));
+        n2 = n2->next;
+        if (newtgt->awaitingconfirm == 0) {
+            continue;
+        }
+
+        /* This target has been added since we last reloaded config so
+         * announce it. */
+        if (announce_sip_target_change(currstate, newtgt, existing, 1) < 0) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int reload_voipintercepts(provision_state_t *currstate,
+        voipintercept_t *currvoip, voipintercept_t *newvoip,
+		prov_intercept_conf_t *intconf, int droppedcols, int droppedmeds) {
+
+    voipintercept_t *voipint, *tmp, *newequiv;
+    char *str;
+
+    /* TODO error handling in the "inform other components about changes"
+     * functions?
+     */
+    HASH_ITER(hh_liid, currvoip, voipint, tmp) {
+        HASH_FIND(hh_liid, newvoip, voipint->common.liid,
+                voipint->common.liid_len, newequiv);
+
+        if (newequiv && currstate->ignorertpcomfort) {
+            newequiv->options |= (1 << OPENLI_VOIPINT_OPTION_IGNORE_COMFORT);
+        }
+
+        if (!newequiv) {
+            /* Intercept has been withdrawn entirely */
+            if (!droppedcols) {
+                halt_existing_intercept(currstate, (void *)voipint,
+                        OPENLI_PROTO_HALT_VOIPINTERCEPT);
+            }
+            remove_liid_mapping(currstate, voipint->common.liid,
+                    voipint->common.liid_len, droppedmeds);
+            continue;
+        } else if (!voip_intercept_equal(voipint, newequiv)) {
+            /* VOIP intercept has changed somehow -- this probably
+             * shouldn't happen but deal with it anyway
+             */
+            logger(LOG_INFO,
+                    "OpenLI provisioner: Details for VOIP intercept %s have changed -- updating collectors",
+                    voipint->common.liid);
+
+            if (!droppedcols) {
+                halt_existing_intercept(currstate, (void *)voipint,
+                        OPENLI_PROTO_HALT_VOIPINTERCEPT);
+            }
+            remove_liid_mapping(currstate, voipint->common.liid,
+                    voipint->common.liid_len, droppedmeds);
+
+        } else if (voipint->options != newequiv->options &&
+                HASH_CNT(hh, currstate->collectors) > 0) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: Options for VOIP intercept %s have changed",
+                    voipint->common.liid);
+            if (!droppedcols) {
+                modify_existing_intercept_options(currstate, (void *)newequiv,
+                        OPENLI_PROTO_MODIFY_IPINTERCEPT);
+            }
+        } else {
+            if (compare_sip_targets(currstate, voipint, newequiv) < 0) {
+                return -1;
+            }
+            newequiv->awaitingconfirm = 0;
+        }
+    }
+
+    HASH_ITER(hh_liid, newvoip, voipint, tmp) {
+        liid_hash_t *h = NULL;
+        int skip = 0;
+        prov_agency_t *lea = NULL;
+
+        if (!voipint->awaitingconfirm) {
+            continue;
+        }
+
+        if (strcmp(voipint->common.targetagency, "pcapdisk") != 0) {
+            HASH_FIND_STR(intconf->leas, voipint->common.targetagency, lea);
+            if (lea == NULL) {
+                skip = 1;
+            }
+        }
+
+        if (skip) {
+            continue;
+        }
+
+        if (currstate->ignorertpcomfort) {
+            newequiv->options |= (1 << OPENLI_VOIPINT_OPTION_IGNORE_COMFORT);
+        }
+
+        /* Add the LIID mapping */
+        h = add_liid_mapping(intconf, voipint->common.liid,
+                voipint->common.targetagency);
+
+        if (!droppedmeds && announce_liidmapping_to_mediators(currstate,
+                h) == -1) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: unable to announce new VOIP intercept to mediators.");
+            return -1;
+        }
+        if (!droppedcols && announce_single_intercept(currstate,
+                (void *)voipint, push_voipintercept_onto_net_buffer) == -1) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: unable to announce new VOIP intercept to collectors.");
+            return -1;
+        }
+
+        if (!droppedcols && announce_all_sip_targets(currstate, voipint) < 0) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: error pushing SIP targets for VOIP intercept %s onto buffer.", voipint->common.liid);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int reload_ipintercepts(provision_state_t *currstate,
+        ipintercept_t *currints, ipintercept_t *newints,
+		prov_intercept_conf_t *intconf, int droppedcols, int droppedmeds) {
+
+    ipintercept_t *ipint, *tmp, *newequiv;
+    char *str;
+
+    /* TODO error handling in the "inform other components about changes"
+     * functions?
+     */
+    HASH_ITER(hh_liid, currints, ipint, tmp) {
+        HASH_FIND(hh_liid, newints, ipint->common.liid,
+                ipint->common.liid_len, newequiv);
+        if (!newequiv) {
+            /* Intercept has been withdrawn entirely */
+            if (!droppedcols) {
+                halt_existing_intercept(currstate, (void *)ipint,
+                        OPENLI_PROTO_HALT_IPINTERCEPT);
+            }
+            remove_liid_mapping(currstate, ipint->common.liid,
+                    ipint->common.liid_len, droppedmeds);
+            logger(LOG_INFO, "OpenLI provisioner: LIID %s has been withdrawn",
+                    ipint->common.liid);
+            continue;
+        } else if (!ip_intercept_equal(ipint, newequiv)) {
+            /* IP intercept has changed somehow -- this probably
+             * shouldn't happen but deal with it anyway
+             */
+            logger(LOG_INFO, "OpenLI provisioner: Details for IP intercept %s have changed -- updating collectors",
+                    ipint->common.liid);
+
+            if (!droppedcols) {
+                modify_existing_intercept_options(currstate, (void *)newequiv,
+                        OPENLI_PROTO_MODIFY_IPINTERCEPT);
+                newequiv->awaitingconfirm = 0;
+            }
+
+            if (strcmp(ipint->common.targetagency,
+                    newequiv->common.targetagency) != 0) {
+                remove_liid_mapping(currstate, ipint->common.liid,
+                        ipint->common.liid_len, droppedmeds);
+            }
+        } else {
+            reload_staticips(currstate, ipint, newequiv);
+            newequiv->awaitingconfirm = 0;
+        }
+    }
+
+    HASH_ITER(hh_liid, newints, ipint, tmp) {
+        liid_hash_t *h = NULL;
+        int skip = 0;
+        prov_agency_t *lea = NULL;
+
+        if (!ipint->awaitingconfirm) {
+            continue;
+        }
+
+        if (strcmp(ipint->common.targetagency, "pcapdisk") != 0) {
+            HASH_FIND_STR(intconf->leas, ipint->common.targetagency, lea);
+            if (lea == NULL) {
+                skip = 1;
+            }
+        }
+
+        if (skip) {
+            continue;
+        }
+
+        /* Add the LIID mapping */
+        h = add_liid_mapping(intconf, ipint->common.liid,
+                ipint->common.targetagency);
+
+        if (!droppedmeds && announce_liidmapping_to_mediators(currstate,
+                h) == -1) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: unable to announce new IP intercept to mediators.");
+            return -1;
+        }
+
+        if (!droppedcols && announce_single_intercept(currstate,
+                (void *)ipint, push_ipintercept_onto_net_buffer) == -1) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: unable to announce new IP intercept to collectors.");
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int reload_intercept_config(provision_state_t *currstate,
+        int mediatorchanged, int clientchanged) {
+    prov_intercept_conf_t newconf;
+
+    init_intercept_config(&newconf);
+
+    if (parse_intercept_config(currstate->interceptconffile, &(newconf)) == -1)
+    {
+        logger(LOG_INFO, "OpenLI provisioner: error while parsing intercept config file '%s'", currstate->interceptconffile);
+        return -1;
+    }
+
+    pthread_mutex_lock(&(currstate->interceptconf.safelock));
+    currstate->interceptconf.destroy_pending = 1;
+    pthread_mutex_unlock(&(currstate->interceptconf.safelock));
+
+    /* Check each section of the config for changes and update the
+     * collectors and mediators accordingly.
+     */
+    if (!mediatorchanged) {
+        if (reload_leas(currstate, &(currstate->interceptconf), &newconf) < 0) {
+            return -1;
+        }
+    }
+
+    if (!clientchanged) {
+        if (reload_coreservers(currstate,
+                currstate->interceptconf.radiusservers, newconf.radiusservers)
+                < 0) {
+            return -1;
+        }
+
+        if (reload_coreservers(currstate,
+                currstate->interceptconf.sipservers, newconf.sipservers) < 0) {
+            return -1;
+        }
+
+        if (reload_coreservers(currstate,
+                currstate->interceptconf.gtpservers, newconf.gtpservers) < 0) {
+            return -1;
+        }
+
+        if (reload_default_radius_users(currstate,
+                currstate->interceptconf.defradusers, newconf.defradusers) < 0)
+        {
+            return -1;
+        }
+    }
+
+	if (reload_voipintercepts(currstate,
+				currstate->interceptconf.voipintercepts,
+				newconf.voipintercepts, &newconf,
+				clientchanged, mediatorchanged) < 0) {
+		return -1;
+	}
+
+	if (reload_ipintercepts(currstate,
+				currstate->interceptconf.ipintercepts,
+				newconf.ipintercepts, &newconf,
+				clientchanged, mediatorchanged) < 0) {
+		return -1;
+    }
+
+    clear_intercept_state(&(currstate->interceptconf));
+    currstate->interceptconf = newconf;
+    return 0;
+}
+
+static inline int reload_voipoptions_config(provision_state_t *currstate,
+        provision_state_t *newstate) {
+
+    if (currstate->ignorertpcomfort != newstate->ignorertpcomfort) {
+        currstate->ignorertpcomfort = newstate->ignorertpcomfort;
+        if (currstate->ignorertpcomfort) {
+            logger(LOG_INFO, "OpenLI: provisioner ignoring RTP comfort noise for all VOIP intercepts");
+        } else {
+            logger(LOG_INFO, "OpenLI: provisioner intercepting RTP comfort noise for all VOIP intercepts");
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+static inline int reload_collector_socket_config(provision_state_t *currstate,
+        provision_state_t *newstate) {
+
+    struct epoll_event ev;
+
+    /* TODO this will trigger on a whitespace change */
+    if (strcmp(newstate->listenaddr, currstate->listenaddr) != 0 ||
+            strcmp(newstate->listenport, currstate->listenport) != 0) {
+
+        logger(LOG_INFO,
+                "OpenLI provisioner: collector listening socket configuration has changed.");
+        stop_all_collectors(currstate->epoll_fd, &(currstate->collectors));
+
+        if (epoll_ctl(currstate->epoll_fd, EPOLL_CTL_DEL,
+                currstate->clientfd->fd, &ev) == -1) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: Failed to remove mediator fd from epoll: %s.",
+                    strerror(errno));
+            return -1;
+        }
+
+        close(currstate->clientfd->fd);
+        free(currstate->clientfd);
+        free(currstate->listenaddr);
+        free(currstate->listenport);
+        currstate->listenaddr = strdup(newstate->listenaddr);
+        currstate->listenport = strdup(newstate->listenport);
+
+        if (start_main_listener(currstate) == -1) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: Warning, listening socket did not restart. Will not be able to accept collector clients.");
+            return -1;
+        }
+        return 1;
+    }
+    return 0;
+}
+
+static inline int reload_mediator_socket_config(provision_state_t *currstate,
+        provision_state_t *newstate) {
+
+    struct epoll_event ev;
+
+    /* TODO this will trigger on a whitespace change */
+    if (strcmp(newstate->mediateaddr, currstate->mediateaddr) != 0 ||
+            strcmp(newstate->mediateport, currstate->mediateport) != 0) {
+
+        free_all_mediators(currstate->epoll_fd, &(currstate->mediators));
+
+        if (epoll_ctl(currstate->epoll_fd, EPOLL_CTL_DEL,
+                currstate->mediatorfd->fd, &ev) == -1) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: Failed to remove mediator fd from epoll: %s.",
+                    strerror(errno));
+            return -1;
+        }
+
+        close(currstate->mediatorfd->fd);
+        free(currstate->mediatorfd);
+        free(currstate->mediateaddr);
+        free(currstate->mediateport);
+        currstate->mediateaddr = strdup(newstate->mediateaddr);
+        currstate->mediateport = strdup(newstate->mediateport);
+
+        logger(LOG_INFO,
+                "OpenLI provisioner: mediation socket configuration has changed.");
+        if (start_mediator_listener(currstate) == -1) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: Warning, mediation socket did not restart. Will not be able to control mediators.");
+            return -1;
+        }
+        return 1;
+    }
+    return 0;
+}
+
+static inline int reload_push_socket_config(provision_state_t *currstate,
+        provision_state_t *newstate) {
+
+    struct epoll_event ev;
+    int changed = 0;
+
+    /* TODO this will trigger on a whitespace change */
+
+    if (strcmp(newstate->pushport, currstate->pushport) != 0 ||
+            (currstate->pushaddr == NULL && newstate->pushaddr != NULL) ||
+            (currstate->pushaddr != NULL && newstate->pushaddr == NULL) ||
+            (currstate->pushaddr && newstate->pushaddr &&
+             strcmp(newstate->pushaddr, currstate->pushaddr) != 0)) {
+
+        if (currstate->updatedaemon) {
+            MHD_stop_daemon(currstate->updatedaemon);
+        }
+        currstate->updatedaemon = NULL;
+
+        if (currstate->pushaddr) {
+            free(currstate->pushaddr);
+        }
+        free(currstate->pushport);
+
+        if (newstate->pushaddr) {
+            currstate->pushaddr = newstate->pushaddr;
+            newstate->pushaddr = NULL;
+        } else {
+            currstate->pushaddr = NULL;
+        }
+        currstate->pushport = newstate->pushport;
+        newstate->pushport = NULL;
+        changed = 1;
+    }
+
+    if (changed) {
+        logger(LOG_INFO,
+                "OpenLI provisioner: update socket configuration has changed.");
+        if (strcmp(currstate->pushport, "0") == 0) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: disabling update socket.");
+            logger(LOG_INFO,
+                    "OpenLI provisioner: warning -- intercept configuration can not be updated while the provisioner is running.");
+            currstate->updatesockfd = -1;
+        } else {
+            currstate->updatesockfd = create_listener(currstate->pushaddr,
+                    currstate->pushport, "update socket");
+
+            if (currstate->updatesockfd != -1) {
+                start_mhd_daemon(currstate);
+            }
+
+            if (currstate->updatesockfd == -1 || currstate->updatedaemon == NULL) {
+                logger(LOG_INFO,
+                        "OpenLI provisioner: Warning, update socket did not restart. Will not be able to receive live updates.");
+                return -1;
+            }
+        }
+        return 1;
+    }
+    return 0;
+
+}
+
+
+int reload_provisioner_config(provision_state_t *currstate) {
+	provision_state_t newstate;
+    int mediatorchanged = 0;
+    int clientchanged = 0;
+    int pushchanged = 0;
+    int leachanged = 0;
+    int tlschanged = 0;
+    int voipoptschanged = 0;
+
+    if (init_prov_state(&newstate, currstate->conffile) == -1) {
+        logger(LOG_INFO,
+                "OpenLI: Error reloading config file for provisioner.");
+        return -1;
+    }
+
+    /* Only make changes if the relevant configuration has changed, so as
+     * to minimise interruptions.
+     */
+    mediatorchanged = reload_mediator_socket_config(currstate, &newstate);
+    if (mediatorchanged == -1) {
+        clear_prov_state(&newstate);
+        return -1;
+    }
+
+    pushchanged = reload_push_socket_config(currstate, &newstate);
+    if (pushchanged == -1) {
+        clear_prov_state(&newstate);
+        return -1;
+    }
+
+    clientchanged = reload_collector_socket_config(currstate, &newstate);
+    if (clientchanged == -1) {
+        clear_prov_state(&newstate);
+        return -1;
+    }
+
+    tlschanged = reload_ssl_config(&(currstate->sslconf), &(newstate.sslconf));
+    if (tlschanged == -1) {
+        clear_prov_state(&newstate);
+        return -1;
+    }
+
+    if (reload_intercept_config_filename(currstate, &newstate) < 0) {
+        clear_prov_state(&newstate);
+        return -1;
+    }
+
+    voipoptschanged = reload_voipoptions_config(currstate, &newstate);
+    if (voipoptschanged && !clientchanged) {
+        voipintercept_t *vint, *tmp;
+
+        pthread_mutex_lock(&(currstate->interceptconf.safelock));
+        HASH_ITER(hh_liid, currstate->interceptconf.voipintercepts, vint, tmp) {
+            if (currstate->ignorertpcomfort) {
+                vint->options |= (1UL << OPENLI_VOIPINT_OPTION_IGNORE_COMFORT);
+            } else {
+                vint->options &= ~(1UL << OPENLI_VOIPINT_OPTION_IGNORE_COMFORT);
+            }
+
+            modify_existing_intercept_options(currstate, (void *)vint,
+                    OPENLI_PROTO_MODIFY_VOIPINTERCEPT);
+        }
+        pthread_mutex_unlock(&(currstate->interceptconf.safelock));
+    }
+
+    if (tlschanged != 0) {
+        if (!mediatorchanged) {
+            free_all_mediators(currstate->epoll_fd, &(currstate->mediators));
+            mediatorchanged = 1;
+        }
+        if (!clientchanged) {
+            stop_all_collectors(currstate->epoll_fd, &(currstate->collectors));
+            clientchanged = 1;
+        }
+    }
+
+    if (mediatorchanged && !clientchanged) {
+        /* Tell all collectors to drop their mediators until further notice */
+        disconnect_mediators_from_collectors(currstate);
+
+    }
+
+    if (reload_intercept_config(currstate, mediatorchanged, clientchanged) < 0)
+    {
+        clear_prov_state(&newstate);
+        return -1;
+    }
+
+    clear_prov_state(&newstate);
+
+    return 0;
+
+
+}
+
+// vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/src/provisioner/provisioner.h
+++ b/src/provisioner/provisioner.h
@@ -191,6 +191,7 @@ typedef struct prov_intercept_conf {
     /** A set of default RADIUS user names */
     default_radius_user_t *defradusers;
 
+    int destroy_pending;
     /** A mutex to protect the intercept config from race conditions */
     pthread_mutex_t safelock;
 } prov_intercept_conf_t;
@@ -274,8 +275,23 @@ struct prov_sock_state {
     int clientrole;
 };
 
+/* Implemented in provisioner.c, but included here to be available
+ * inside hup_reload.c
+ */
+int init_prov_state(provision_state_t *state, char *configfile);
+void clear_prov_state(provision_state_t *state);
+void free_all_mediators(int epollfd, prov_mediator_t **mediators);
+void stop_all_collectors(int epollfd, prov_collector_t **collectors);
+int start_main_listener(provision_state_t *state);
+int start_mediator_listener(provision_state_t *state);
+void start_mhd_daemon(provision_state_t *state);
+void clear_intercept_state(prov_intercept_conf_t *conf);
+void init_intercept_config(prov_intercept_conf_t *conf);
+
+/* Implemented in configwriter.c */
 int emit_intercept_config(char *configfile, prov_intercept_conf_t *conf);
 
+/* Implemented in clientupdates.c */
 int announce_default_radius_username(provision_state_t *state,
         default_radius_user_t *raduser);
 int withdraw_default_radius_username(provision_state_t *state,
@@ -309,6 +325,11 @@ int announce_single_intercept(provision_state_t *state,
         void *cept, int (*sendfunc)(net_buffer_t *, void *));
 liid_hash_t *add_liid_mapping(prov_intercept_conf_t *conf,
         char *liid, char *agency);
+
+/* Implemented in hup_reload.c */
+int reload_provisioner_config(provision_state_t *state);
+
+
 #endif
 
 // vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/src/util.c
+++ b/src/util.c
@@ -41,6 +41,27 @@
 #include "logger.h"
 #include "util.h"
 
+void openli_copy_ipcontent(libtrace_packet_t *pkt, uint8_t **ipc,
+        uint16_t *iplen) {
+
+    void *l3;
+    uint16_t ethertype;
+    uint32_t rem;
+
+    *ipc = NULL;
+    *iplen = 0;
+
+    l3 = trace_get_layer3(pkt, &ethertype, &rem);
+
+    if (l3 == NULL || rem == 0) {
+        return;
+    }
+
+	*ipc = malloc(rem);
+	memcpy(*ipc, l3, rem);
+	*iplen = rem;
+}
+
 int connect_socket(char *ipstr, char *portstr, uint8_t isretry,
         uint8_t setkeepalive) {
 

--- a/src/util.h
+++ b/src/util.h
@@ -52,6 +52,8 @@ struct addrinfo *populate_addrinfo(char *ipstr, char *portstr,
 void *get_udp_payload(libtrace_packet_t *packet, uint32_t *rem,
         uint16_t *sourceport, uint16_t *destport);
 char *parse_iprange_string(char *ipr_str);
+void openli_copy_ipcontent(libtrace_packet_t *pkt, uint8_t **ipc,
+        uint16_t *iplen);
 
 uint32_t hash_liid(char *liid);
 uint32_t hashlittle( const void *key, size_t length, uint32_t initval);


### PR DESCRIPTION
Two major features in this PR:
 * Ensure that GTP request / response pairs that reach the sync thread in the wrong order (due to parallelism or multi-interface input issues) are correctly processed. Should resolve some issues that we saw when testing with Datora.
 * Re-enabled ability for a provisioner to reload the intercept config from the file on disk upon receiving a SIGHUP. This feature had been removed because the REST API made it somewhat redundant, but there are existing deployments that are making use of this feature so I would like it to still work for a while yet.