### PR TITLE
Resolve #45

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,11 +71,11 @@ if test "x$enable_collector" != "xno"; then
 fi
 
 if test "x$enable_provisioner" != "xno"; then
-        AC_CHECK_LIB([microhttpd], [MHD_destroy_post_processor],,libmicrohttpd_found=0)
+        AC_CHECK_LIB([microhttpd], [MHD_destroy_post_processor],libmicrohttpd_found=1,libmicrohttpd_found=0)
         if test "$libmicrohttpd_found" = 0; then
                 AC_MSG_ERROR(Required library libmicrohttpd not found; use LDFLAGS to specify library location)
         fi
-        AC_CHECK_LIB([json-c], [json_tokener_new],,libjsonc_found=0)
+        AC_CHECK_LIB([json-c], [json_tokener_new],libjsonc_found=1,libjsonc_found=0)
 
         if test "$libjsonc_found" = 0; then
                 AC_MSG_ERROR(Required library libjson-c not found; use LDFLAGS to specify library location)

--- a/debian/control
+++ b/debian/control
@@ -28,8 +28,7 @@ Description: Central provisioning daemon for an OpenLI system
 Package: openli-mediator
 Section: net
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libwandder1-dev,
- libjudy-dev, lsb-base, libzmq3-dev
+Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base
 Recommends: strongswan
 Description: Mediation daemon for an OpenLI system
  OpenLI is a software suite that allows network operators to conduct
@@ -45,9 +44,7 @@ Description: Mediation daemon for an OpenLI system
 Package: openli-collector
 Section: net
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libwandder1-dev,
- libjudy-dev, libgoogle-perftools-dev, libosip2-dev, lsb-base,
- libzmq3-dev
+Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base
 Description: Collector daemon for an OpenLI system
  OpenLI is a software suite that allows network operators to conduct
  lawful interception of Internet traffic that is compliant with the


### PR DESCRIPTION
The OpenLI provisioner will now create an empty intercept config file if no file exists at the location configured in the provisioner config (as opposed to halting with an error).

Also includes a fix for a bug when adding 'pcapdisk' intercepts using the REST API.