### PR TITLE
Default intercept file

### DIFF
--- a/src/provisioner/provisioner.h
+++ b/src/provisioner/provisioner.h
@@ -34,7 +34,7 @@
 #include "util.h"
 #include "openli_tls.h"
 
-#define DEFAULT_INTERCEPT_CONFIG_FILE "/var/lib/openli/intercepts.conf"
+#define DEFAULT_INTERCEPT_CONFIG_FILE "/etc/openli/running-intercept-config.yaml"
 
 #ifndef MHD_SOCKET_DEFINED
 typedef int MHD_socket;


### PR DESCRIPTION
Make default in code match the config examples supplied (provisioner will not start without the specified file - aligning the two will help users)