### PR TITLE
Fix bad behaviour when multiple IP intercepts use the same vendor mirror session ID

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,6 +100,20 @@ build-amd64-ubuntu-disco:
   only:
     - tags
 
+build-amd64-ubuntu-eoan:
+  stage: build
+  image: ubuntu:eoan
+  script:
+    - ./gitlab-build.sh
+    - mkdir -p built-packages/eoan/
+    - mv ../*.deb built-packages/eoan/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
 build-amd64-fedora-29:
   stage: build
   image: fedora:29
@@ -128,6 +142,20 @@ build-amd64-fedora-30:
   only:
     - tags
 
+build-amd64-fedora-31:
+  stage: build
+  image: fedora:31
+  script:
+    - ./gitlab-build-rpm.sh fedora31
+    - mkdir -p built-packages/fedora_31/
+    - mv ~/rpmbuild/RPMS/x86_64/*.rpm built-packages/fedora_31/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
 build-amd64-centos7:
   stage: build
   image: centos:7
@@ -135,6 +163,20 @@ build-amd64-centos7:
     - ./gitlab-build-rpm.sh centos7
     - mkdir -p built-packages/centos_7/
     - mv ~/rpmbuild/RPMS/x86_64/*.rpm built-packages/centos_7/
+  artifacts:
+    paths:
+      - built-packages/*
+    expire_in: 1 day
+  only:
+    - tags
+
+build-amd64-centos8:
+  stage: build
+  image: centos:8
+  script:
+    - ./gitlab-build-rpm.sh centos8
+    - mkdir -p built-packages/centos_8/
+    - mv ~/rpmbuild/RPMS/x86_64/*.rpm built-packages/centos_8/
   artifacts:
     paths:
       - built-packages/*

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+openli (1.0.4-1) UNRELEASED; urgency=medium
+
+  * Added REST API to provisioner to allow intercepts, agencies and
+    core servers to be manipulated by sending HTTP requests to a
+    listening socket.
+  * Intercept config has been separated from provisioner config.
+  * Added support for UMTS (mobile) intercepts using GTP.
+  * Allow RADIUS Calling-Station-ID to be used for determining user
+    identity.
+  * Allow multiple concurrent RADIUS sessions for a single user
+    (e.g. simultaneous IPv4 and IPv6 sessions).
+  * Many bug fixes (as documented in
+    https://github.com/wanduow/openli/wiki/ChangeLog).
+
+ -- Shane Alcock <shane.alcock@waikato.ac.nz>  Wed, 18 Dec 2019 10:15:20 +1300
+
 openli (1.0.4-1~gtptest03) UNRELEASED; urgency=medium
 
   * Pre-release packaging of 1.0.4 for Datora to use for testing the

--- a/gitlab-build-rpm.sh
+++ b/gitlab-build-rpm.sh
@@ -1,7 +1,7 @@
 set -x -e -o pipefail
 
 if [ "${CI_COMMIT_REF_NAME}" = "" ]; then
-        CI_COMMIT_REF_NAME=1.0.2
+        CI_COMMIT_REF_NAME=1.0.4
 fi
 
 export QA_RPATHS=$[ 0x0001 ]
@@ -9,6 +9,10 @@ SOURCENAME=`echo ${CI_COMMIT_REF_NAME} | cut -d '-' -f 1`
 
 
 DISTRO=fedora
+if [ "$1" = "centos8" ]; then
+        DISTRO=centos
+fi
+
 if [ "$1" = "centos7" ]; then
         DISTRO=centos
 fi
@@ -51,6 +55,13 @@ enabled=1
 EOF
 
 yum install -y wget make gcc
+
+if [ "$1" = "centos8" ]; then
+        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true
+        dnf install -y 'dnf-command(config-manager)' || true
+        yum config-manager --set-enabled PowerTools || true
+fi
+
 
 if [ "$1" = "centos7" ]; then
         yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true

--- a/rpm/openli.spec
+++ b/rpm/openli.spec
@@ -1,5 +1,5 @@
 Name:           openli
-Version:        1.0.3
+Version:        1.0.4
 Release:        1%{?dist}
 Summary:        Software for performing ETSI-compliant lawful intercept
 
@@ -173,6 +173,9 @@ fi
 
 
 %changelog
+* Mon Jan 13 2020 Shane Alcock <salcock@waikato.ac.nz> - 1.0.4-1
+- Updated for 1.0.4 release
+
 * Fri Aug 16 2019 Shane Alcock <salcock@waikato.ac.nz> - 1.0.3-1
 - Updated for 1.0.3 release
 

--- a/src/collector/accessplugins/gtp.c
+++ b/src/collector/accessplugins/gtp.c
@@ -1295,13 +1295,7 @@ static inline access_session_t *find_matched_session(access_plugin_t *p,
         return NULL;
     }
 
-    thissess = *sesslist;
-    while (thissess != NULL) {
-        if (strcmp(thissess->sessionid, match->sessid) == 0) {
-            break;
-        }
-        thissess = thissess->next;
-    }
+    HASH_FIND(hh, *sesslist, match->sessid, strlen(match->sessid), thissess);
 
     if (!thissess) {
         thissess = create_access_session(p, match->sessid,
@@ -1309,8 +1303,8 @@ static inline access_session_t *find_matched_session(access_plugin_t *p,
         thissess->cin = assign_gtp_cin(teid);
         match->cin = thissess->cin;
 
-        thissess->next = *sesslist;
-        *sesslist = thissess;
+        HASH_ADD_KEYPTR(hh, *sesslist, thissess->sessionid,
+                strlen(thissess->sessionid), thissess);
     }
     return thissess;
 }

--- a/src/collector/accessplugins/radius.c
+++ b/src/collector/accessplugins/radius.c
@@ -1529,21 +1529,14 @@ static access_session_t *radius_update_session_state(access_plugin_t *p,
     snprintf(tempstr, 24, "%lu", raddata->acctsess);
     ptr = quickcat(ptr, &rem, tempstr, strlen(tempstr));
 
-    thissess = *sesslist;
-    while (thissess != NULL) {
-        if (strcmp(thissess->sessionid, sessionid) == 0) {
-            break;
-        }
-        thissess = thissess->next;
-    }
+    HASH_FIND(hh, *sesslist, sessionid, strlen(sessionid), thissess);
 
     if (!thissess) {
         thissess = create_access_session(p, sessionid, 5000 - rem);
         thissess->cin = assign_cin(raddata);
 
-        thissess->next = *sesslist;
-        *sesslist = thissess;
-
+        HASH_ADD_KEYPTR(hh, *sesslist, thissess->sessionid,
+                strlen(thissess->sessionid), thissess);
     }
 
     if (raddata->msgtype == RADIUS_CODE_ACCESS_REQUEST ||

--- a/src/collector/alushim_parser.h
+++ b/src/collector/alushim_parser.h
@@ -33,7 +33,7 @@
 
 int check_alu_intercept(collector_identity_t *info, colthread_local_t *loc,
         libtrace_packet_t *packet, packet_info_t *pinfo,
-        coreserver_t *alusources, vendmirror_intercept_t *aluints);
+        coreserver_t *alusources, vendmirror_intercept_list_t *aluints);
 
 #endif
 

--- a/src/collector/collector.h
+++ b/src/collector/collector.h
@@ -192,7 +192,7 @@ typedef struct colthread_local {
     ipv4_target_t *activeipv4intercepts;
 
     rtpstreaminf_t *activertpintercepts;
-    vendmirror_intercept_t *activemirrorintercepts;
+    vendmirror_intercept_list_t *activemirrorintercepts;
 
     staticipsession_t *activestaticintercepts;
 

--- a/src/collector/collector_seqtracker.c
+++ b/src/collector/collector_seqtracker.c
@@ -324,6 +324,7 @@ static int run_encoding_job(seqtracker_thread_data_t *seqdata,
     if (!intstate) {
         logger(LOG_INFO, "Received encoding job for an unknown LIID: %s??",
                 liid);
+        free_published_message(recvd);
         return 0;
     }
 

--- a/src/collector/collector_sync.c
+++ b/src/collector/collector_sync.c
@@ -468,7 +468,6 @@ static inline void push_single_vendmirrorid(libtrace_message_queue_t *q,
         return;
     }
 
-    jm->cin = 0;
     memset(&msg, 0, sizeof(openli_pushed_t));
     msg.type = msgtype;
     msg.data.mirror = jm;
@@ -886,6 +885,7 @@ static void push_existing_user_sessions(collector_sync_t *sync,
 
     if (user) {
         access_session_t *sess, *tmp2;
+
         HASH_ITER(hh, user->sessions, sess, tmp2) {
             HASH_ITER(hh, (sync_sendq_t *)(sync->glob->collector_queues),
                     sendq, tmp) {

--- a/src/collector/internetaccess.c
+++ b/src/collector/internetaccess.c
@@ -74,10 +74,8 @@ void free_single_user(internet_user_t *u) {
         free(u->userid);
     }
 
-    tmp = u->sessions;
-    while (tmp) {
-        sess = tmp;
-        tmp = tmp->next;
+    HASH_ITER(hh, u->sessions, sess, tmp) {
+        HASH_DELETE(hh, u->sessions, sess);
         free_session(sess);
     }
     free(u);
@@ -132,25 +130,7 @@ int free_single_session(internet_user_t *user, access_session_t *sess) {
         return -1;
     }
 
-    tmp = user->sessions;
-    prev = NULL;
-    while (tmp) {
-        if (sess == tmp) {
-            break;
-        }
-        prev = tmp;
-        tmp = tmp->next;
-    }
-
-    //HASH_DELETE(hh, user->sessions, sess);
-    if (tmp != NULL) {
-        if (prev) {
-            prev->next = tmp->next;
-        } else {
-            user->sessions = tmp->next;
-        }
-    }
-
+    HASH_DELETE(hh, user->sessions, sess);
     free_session(sess);
     return 0;
 }

--- a/src/collector/internetaccess.h
+++ b/src/collector/internetaccess.h
@@ -109,7 +109,6 @@ struct access_session {
 
     struct timeval started;
 
-    access_session_t *next;
     UT_hash_handle hh;
 } ;
 

--- a/src/collector/jmirror_parser.c
+++ b/src/collector/jmirror_parser.c
@@ -46,7 +46,7 @@ static inline uint32_t jmirror_get_interceptid(jmirrorhdr_t *header) {
 
 static void push_jmirror_ipcc_job(colthread_local_t *loc,
         libtrace_packet_t *packet, vendmirror_intercept_t *cept,
-        collector_identity_t *info, void *l3, uint32_t rem) {
+        uint32_t cin, collector_identity_t *info, void *l3, uint32_t rem) {
 
     openli_export_recv_t *msg;
 
@@ -56,7 +56,7 @@ static void push_jmirror_ipcc_job(colthread_local_t *loc,
     msg->ts = trace_get_timeval(packet);
     msg->destid = cept->common.destid;
     msg->data.ipcc.liid = strdup(cept->common.liid);
-    msg->data.ipcc.cin = cept->cin;
+    msg->data.ipcc.cin = cin;
     msg->data.ipcc.dir = ETSI_DIR_INDETERMINATE;
     msg->data.ipcc.ipcontent = (uint8_t *)calloc(1, rem);
     msg->data.ipcc.ipclen = rem;
@@ -69,12 +69,14 @@ static void push_jmirror_ipcc_job(colthread_local_t *loc,
 
 int check_jmirror_intercept(collector_identity_t *info, colthread_local_t *loc,
         libtrace_packet_t *packet, packet_info_t *pinfo,
-        coreserver_t *jmirror_sources, vendmirror_intercept_t *jmirror_ints) {
+        coreserver_t *jmirror_sources,
+        vendmirror_intercept_list_t *jmirror_ints) {
 
     coreserver_t *cs;
     jmirrorhdr_t *header = NULL;
-    uint32_t rem = 0, cept_id;
-    vendmirror_intercept_t *cept;
+    uint32_t rem = 0, cept_id, cin;
+    vendmirror_intercept_t *cept, *tmp;
+    vendmirror_intercept_list_t *vmilist;
     char *l3;
 
     if ((cs = match_packet_to_coreserver(jmirror_sources, pinfo)) == NULL) {
@@ -88,8 +90,8 @@ int check_jmirror_intercept(collector_identity_t *info, colthread_local_t *loc,
 
     cept_id = jmirror_get_interceptid(header);
 
-    HASH_FIND(hh, jmirror_ints, &cept_id, sizeof(cept_id), cept);
-    if (cept == NULL) {
+    HASH_FIND(hh, jmirror_ints, &cept_id, sizeof(cept_id), vmilist);
+    if (vmilist == NULL) {
         return 0;
     }
 
@@ -99,9 +101,11 @@ int check_jmirror_intercept(collector_identity_t *info, colthread_local_t *loc,
     if (rem == 0) {
         return 0;
     }
+    cin = ntohl(header->sessionid);
 
-    cept->cin = ntohl(header->sessionid);
-    push_jmirror_ipcc_job(loc, packet, cept, info, l3, rem);
+    HASH_ITER(hh, vmilist->intercepts, cept, tmp) {
+        push_jmirror_ipcc_job(loc, packet, cept, cin, info, l3, rem);
+    }
     return 1;
 
 }

--- a/src/collector/jmirror_parser.h
+++ b/src/collector/jmirror_parser.h
@@ -33,7 +33,7 @@
 
 int check_jmirror_intercept(collector_identity_t *info, colthread_local_t *loc,
         libtrace_packet_t *packet, packet_info_t *pinfo,
-        coreserver_t *alusources, vendmirror_intercept_t *jmirrors);
+        coreserver_t *alusources, vendmirror_intercept_list_t *jmirrors);
 
 #endif
 

--- a/src/intercept.h
+++ b/src/intercept.h
@@ -220,12 +220,16 @@ struct ipsession {
 };
 
 struct vendmirror_intercept {
-    uint32_t cin;
-    uint32_t interceptid;
-    uint32_t nextseqno;
+    uint32_t sessionid;
     intercept_common_t common;
     UT_hash_handle hh;
 };
+
+typedef struct vendmirror_intercept_list {
+    uint32_t sessionid;
+    vendmirror_intercept_t *intercepts;
+    UT_hash_handle hh;
+} vendmirror_intercept_list_t;
 
 struct staticipsession {
     char *key;
@@ -256,7 +260,7 @@ void free_all_ipintercepts(ipintercept_t **interceptlist);
 void free_all_voipintercepts(voipintercept_t **vintercepts);
 void free_all_rtpstreams(rtpstreaminf_t **streams);
 void free_all_ipsessions(ipsession_t **sessions);
-void free_all_vendmirror_intercepts(vendmirror_intercept_t **mirror_intercepts);
+void free_all_vendmirror_intercepts(vendmirror_intercept_list_t **mirror_intercepts);
 void free_all_staticipsessions(staticipsession_t **statintercepts);
 
 void free_voip_cinmap(voipcinmap_t *cins);


### PR DESCRIPTION
Also included:
 * updates to packaging systems for 1.0.4 release
 * added recent releases of Ubuntu, Centos and Fedora to packaging scripts
 * fixed a memory leak that occurs when encoding jobs are created that do not match an LIID that the sequence tracker thread knows about.