### PR TITLE
Minor fixes

### DIFF
--- a/src/collector/accessplugins/radius.c
+++ b/src/collector/accessplugins/radius.c
@@ -67,6 +67,7 @@ enum {
     RADIUS_ATTR_ACCT_SESSION_ID = 44,
     RADIUS_ATTR_ACCT_TERMINATE_CAUSE = 49,
     RADIUS_ATTR_FRAMED_IPV6_PREFIX = 97,
+    RADIUS_ATTR_DELEGATED_IPV6_PREFIX = 123,
     RADIUS_ATTR_FRAMED_IPV6_ADDRESS = 168,
 };
 
@@ -253,6 +254,7 @@ static inline int interesting_attribute(uint8_t attrnum) {
         case RADIUS_ATTR_CALLED_STATION_ID:
         case RADIUS_ATTR_CALLING_STATION_ID:
         case RADIUS_ATTR_ACCT_TERMINATE_CAUSE:
+        case RADIUS_ATTR_DELEGATED_IPV6_PREFIX:
             return 1;
     }
 
@@ -1085,7 +1087,8 @@ static inline void extract_assigned_ip_address(radius_global_t *glob,
             return;
         }
 
-        if (attr->att_type == RADIUS_ATTR_FRAMED_IPV6_PREFIX) {
+        if (attr->att_type == RADIUS_ATTR_FRAMED_IPV6_PREFIX ||
+                attr->att_type == RADIUS_ATTR_DELEGATED_IPV6_PREFIX) {
             struct sockaddr_in6 *in6;
             radius_v6_prefix_attr_t *prefattr;
 

--- a/src/collector/accessplugins/radius.c
+++ b/src/collector/accessplugins/radius.c
@@ -282,7 +282,7 @@ static inline radius_attribute_t *create_new_attribute(radius_global_t *glob,
         if (attr->att_len > STANDARD_ATTR_ALLOC) {
             attr->att_val = malloc(attr->att_len);
         } else {
-            attr->att_val = malloc(STANDARD_ATTR_ALLOC);
+            attr->att_val = calloc(1, STANDARD_ATTR_ALLOC);
         }
     } else if (attr->att_len > STANDARD_ATTR_ALLOC) {
         attr->att_val = realloc(attr->att_val, attr->att_len);
@@ -1087,8 +1087,7 @@ static inline void extract_assigned_ip_address(radius_global_t *glob,
             return;
         }
 
-        if (attr->att_type == RADIUS_ATTR_FRAMED_IPV6_PREFIX ||
-                attr->att_type == RADIUS_ATTR_DELEGATED_IPV6_PREFIX) {
+        if (attr->att_type == RADIUS_ATTR_DELEGATED_IPV6_PREFIX) {
             struct sockaddr_in6 *in6;
             radius_v6_prefix_attr_t *prefattr;
 
@@ -1099,10 +1098,11 @@ static inline void extract_assigned_ip_address(radius_global_t *glob,
             in6->sin6_flowinfo = 0;
 
             prefattr = (radius_v6_prefix_attr_t *)(attr->att_val);
-            memcpy(&(in6->sin6_addr.s6_addr), prefattr->address, 16);
+            memcpy((in6->sin6_addr.s6_addr), prefattr->address, 16);
 
             sess->sessionip.ipfamily = AF_INET6;
             sess->sessionip.prefixbits = prefattr->preflength;
+
             return;
         }
 

--- a/src/collector/collector.c
+++ b/src/collector/collector.c
@@ -968,6 +968,7 @@ static inline void init_sync_thread_data(collector_global_t *glob,
     sup->collector_queues = NULL;
     sup->epollevs = NULL;
     sup->epoll_fd = epoll_create1(0);
+    sup->total_col_threads = glob->total_col_threads;
 
     sup->stats_mutex = &(glob->stats_mutex);
     sup->stats = &(glob->stats);

--- a/src/collector/collector_base.h
+++ b/src/collector/collector_base.h
@@ -100,6 +100,7 @@ typedef struct sync_thread_global {
     void *collector_queues;
     void *epollevs;
     int epoll_fd;
+    int total_col_threads;
 
     pthread_mutex_t *stats_mutex;
     collector_stats_t *stats;

--- a/src/collector/collector_sync.h
+++ b/src/collector/collector_sync.h
@@ -78,6 +78,7 @@ typedef struct colsync_data {
     SSL *ssl;
     SSL_CTX *ctx;
     uint8_t provconnfailed;
+    uint8_t hellosreceived;
 
 } collector_sync_t;
 

--- a/src/openli_tls.c
+++ b/src/openli_tls.c
@@ -24,6 +24,7 @@
  *
  */
 
+#include <string.h>
 #include <openssl/ssl.h>
 #include "logger.h"
 #include "openli_tls.h"


### PR DESCRIPTION
 * Use Delegated-IPv6-Prefix RADIUS AVP for extracting the IPv6 address range for a user's session
 * Fix a bad memcpy when saving the IPv6 address range from a RADIUS AVP.
 * Fix concurrency issue that was causing duplicate sessions to be announced to the collector's processing threads.
 * Fix valgrind errors due to uninitialised memory for storing RADIUS attribute values. 