### PR TITLE
Fixes for issue #60

### DIFF
--- a/src/collector/accessplugins/gtp.c
+++ b/src/collector/accessplugins/gtp.c
@@ -1054,15 +1054,7 @@ static void extract_gtp_assigned_ip_address(gtp_saved_pkt_t *gpkt,
         if (gpkt->version == 2 && ie->ietype == GTPV2_IE_PDN_ALLOC) {
             if (*((uint8_t *)(ie->iecontent)) == 0x01) {
                 /* IPv4 */
-                struct sockaddr_in *in;
-
-                in = (struct sockaddr_in *)&(sess->sessionip.assignedip);
-                in->sin_family = AF_INET;
-                in->sin_port = 0;
-                in->sin_addr.s_addr = *((uint32_t *)(ie->iecontent + 1));
-
-                sess->sessionip.ipfamily = AF_INET;
-                sess->sessionip.prefixbits = 32;
+                add_new_session_ip(sess, ie->iecontent + 1, AF_INET, 32);
 
                 /* These weird numbers are derived from bytes 3 and 4 of
                  * the Packet Data Protocol Address IE defined in
@@ -1077,29 +1069,14 @@ static void extract_gtp_assigned_ip_address(gtp_saved_pkt_t *gpkt,
 
             } else if (*((uint8_t *)(ie->iecontent)) == 0x02) {
                 /* IPv6 */
-                struct sockaddr_in6 *in6;
-
-                in6 = (struct sockaddr_in6 *)&(sess->sessionip.assignedip);
-                in6->sin6_family = AF_INET6;
-                in6->sin6_port = 0;
-                memcpy(&(in6->sin6_addr.s6_addr), ie->iecontent + 1, 16);
-
-                sess->sessionip.ipfamily = AF_INET6;
-                sess->sessionip.prefixbits = 128;
+                add_new_session_ip(sess, ie->iecontent + 1, AF_INET6, 128);
                 gsess->pdptype = htons(0x0157);
             } else if (*((uint8_t *)(ie->iecontent)) == 0x03) {
                 /* IPv4 AND IPv6 */
 
                 /* TODO support multiple sessionips per session */
-                struct sockaddr_in6 *in6;
+                add_new_session_ip(sess, ie->iecontent + 1, AF_INET6, 128);
 
-                in6 = (struct sockaddr_in6 *)&(sess->sessionip.assignedip);
-                in6->sin6_family = AF_INET6;
-                in6->sin6_port = 0;
-                memcpy(&(in6->sin6_addr.s6_addr), ie->iecontent + 1, 16);
-
-                sess->sessionip.ipfamily = AF_INET6;
-                sess->sessionip.prefixbits = 128;
                 gsess->pdptype = htons(0x018d);
             } else {
                 break;
@@ -1114,28 +1091,11 @@ static void extract_gtp_assigned_ip_address(gtp_saved_pkt_t *gpkt,
 
             if ((pdptype & 0x0fff) == 0x0121) {
                 /* IPv4 */
-                struct sockaddr_in *in;
-
+                add_new_session_ip(sess, ie->iecontent + 2, AF_INET, 32);
                 gsess->pdptype = htons(0x0121);
-
-                in = (struct sockaddr_in *)&(sess->sessionip.assignedip);
-                in->sin_family = AF_INET;
-                in->sin_port = 0;
-                in->sin_addr.s_addr = *((uint32_t *)(ie->iecontent + 2));
-
-                sess->sessionip.ipfamily = AF_INET;
-                sess->sessionip.prefixbits = 32;
             } else if ((pdptype & 0x0fff) == 0x0157) {
                 /* IPv6 */
-                struct sockaddr_in6 *in6;
-
-                in6 = (struct sockaddr_in6 *)&(sess->sessionip.assignedip);
-                in6->sin6_family = AF_INET6;
-                in6->sin6_port = 0;
-                memcpy(&(in6->sin6_addr.s6_addr), ie->iecontent + 2, 16);
-
-                sess->sessionip.ipfamily = AF_INET6;
-                sess->sessionip.prefixbits = 128;
+                add_new_session_ip(sess, ie->iecontent + 2, AF_INET6, 128);
                 gsess->pdptype = htons(0x0157);
             }
             memcpy(&(gsess->pdpaddr), sess, sizeof(internetaccess_ip_t));

--- a/src/collector/accessplugins/radius.c
+++ b/src/collector/accessplugins/radius.c
@@ -346,9 +346,9 @@ static void destroy_radius_nas(radius_nas_t *nas) {
     radius_orphaned_resp_t *orph, *tmporph;
     radius_saved_req_t *req, *tmpreq;
     radius_user_t *user;
-    PWord_t pval;
+    PWord_t pval, pval2;
     char index[128];
-    Word_t res;
+    Word_t res, index2;
 
     index[0] = '\0';
     JSLF(pval, nas->user_map, index);
@@ -361,6 +361,13 @@ static void destroy_radius_nas(radius_nas_t *nas) {
             free(user->nasidentifier);
         }
 
+        index2 = 0;
+        JLF(pval2, user->sessions, index2);
+        while (pval2) {
+            radius_user_session_t *usess = (radius_user_session_t *)(*pval2);
+            free(usess);
+            JLN(pval2, user->sessions, index2);
+        }
         JLFA(res, user->sessions);
         free(user);
 
@@ -1053,55 +1060,24 @@ static inline void extract_assigned_ip_address(radius_global_t *glob,
         return;
     }
 
-    /* TODO is multiple address assignment a thing that happens in reality? */
     attr = attrlist;
     while (attr) {
         if (attr->att_type == RADIUS_ATTR_FRAMED_IP_ADDRESS) {
-            struct sockaddr_in *in;
-
-            in = (struct sockaddr_in *)&(sess->sessionip.assignedip);
-
-            in->sin_family = AF_INET;
-            in->sin_port = 0;
-            in->sin_addr.s_addr = *((uint32_t *)attr->att_val);
-
-            sess->sessionip.ipfamily = AF_INET;
-            sess->sessionip.prefixbits = 32;
-
-            return;
+            add_new_session_ip(sess, attr->att_val, AF_INET, 32);
         }
 
         if (attr->att_type == RADIUS_ATTR_FRAMED_IPV6_ADDRESS) {
-            struct sockaddr_in6 *in6;
-
-            in6 = (struct sockaddr_in6 *)&(sess->sessionip.assignedip);
-
-            in6->sin6_family = AF_INET6;
-            in6->sin6_port = 0;
-            in6->sin6_flowinfo = 0;
-
-            memcpy(&(in6->sin6_addr.s6_addr), attr->att_val, 16);
-
-            sess->sessionip.ipfamily = AF_INET6;
-            sess->sessionip.prefixbits = 128;
-            return;
+            add_new_session_ip(sess, attr->att_val, AF_INET6, 128);
         }
 
-        if (attr->att_type == RADIUS_ATTR_DELEGATED_IPV6_PREFIX) {
-            struct sockaddr_in6 *in6;
+        if (attr->att_type == RADIUS_ATTR_DELEGATED_IPV6_PREFIX ||
+                attr->att_type == RADIUS_ATTR_FRAMED_IPV6_PREFIX) {
+
             radius_v6_prefix_attr_t *prefattr;
-
-            in6 = (struct sockaddr_in6 *)&(sess->sessionip.assignedip);
-
-            in6->sin6_family = AF_INET6;
-            in6->sin6_port = 0;
-            in6->sin6_flowinfo = 0;
-
             prefattr = (radius_v6_prefix_attr_t *)(attr->att_val);
-            memcpy((in6->sin6_addr.s6_addr), prefattr->address, 16);
 
-            sess->sessionip.ipfamily = AF_INET6;
-            sess->sessionip.prefixbits = prefattr->preflength;
+            add_new_session_ip(sess, prefattr->address, AF_INET6,
+                    prefattr->preflength);
 
             return;
         }

--- a/src/collector/collector.c
+++ b/src/collector/collector.c
@@ -263,6 +263,7 @@ static void init_collocal(colthread_local_t *loc, collector_global_t *glob,
     loc->sipservers = NULL;
     loc->staticv4ranges = New_Patricia(32);
     loc->staticv6ranges = New_Patricia(128);
+    loc->dynamicv6ranges = New_Patricia(128);
     loc->staticcache = NULL;
     loc->tosyncq_ip = NULL;
     loc->tosyncq_voip = NULL;
@@ -379,8 +380,10 @@ static void stop_processing_thread(libtrace_t *trace, libtrace_thread_t *t,
     HASH_ITER(hh, loc->activeipv6intercepts, v6, tmp2) {
         free_all_ipsessions(&(v6->intercepts));
         HASH_DELETE(hh, loc->activeipv6intercepts, v6);
+        free(v6->prefixstr);
         free(v6);
     }
+
 
     free_all_staticipsessions(&(loc->activestaticintercepts));
     free_all_rtpstreams(&(loc->activertpintercepts));
@@ -393,6 +396,7 @@ static void stop_processing_thread(libtrace_t *trace, libtrace_thread_t *t,
 
     Destroy_Patricia(loc->staticv4ranges, free_staticrange_data);
     Destroy_Patricia(loc->staticv6ranges, free_staticrange_data);
+    Destroy_Patricia(loc->dynamicv6ranges, free_staticrange_data);
 
     free_staticcache(loc->staticcache);
 }

--- a/src/collector/collector.h
+++ b/src/collector/collector.h
@@ -122,6 +122,8 @@ typedef struct ipv4_target {
 
 typedef struct ipv6_target {
     uint8_t address[16];
+    uint8_t prefixlen;
+    char *prefixstr;
     ipsession_t *intercepts;
 
     UT_hash_handle hh;
@@ -188,8 +190,8 @@ typedef struct colthread_local {
 
 
     /* Current intercepts */
-    ipv6_target_t *activeipv6intercepts;
     ipv4_target_t *activeipv4intercepts;
+    ipv6_target_t *activeipv6intercepts;
 
     rtpstreaminf_t *activertpintercepts;
     vendmirror_intercept_list_t *activemirrorintercepts;
@@ -216,6 +218,7 @@ typedef struct colthread_local {
 
     patricia_tree_t *staticv4ranges;
     patricia_tree_t *staticv6ranges;
+    patricia_tree_t *dynamicv6ranges;
     static_ipcache_t *staticcache;
 
     ipfrag_reassembler_t *fragreass;

--- a/src/collector/collector_publish.c
+++ b/src/collector/collector_publish.c
@@ -70,6 +70,9 @@ void free_published_message(openli_export_recv_t *msg) {
         if (msg->data.ipiri.username) {
             free(msg->data.ipiri.username);
         }
+        if (msg->data.ipiri.assignedips) {
+            free(msg->data.ipiri.assignedips);
+        }
     } else if (msg->type == OPENLI_EXPORT_UMTSIRI) {
         if (msg->data.mobiri.liid) {
             free(msg->data.mobiri.liid);

--- a/src/collector/collector_publish.h
+++ b/src/collector/collector_publish.h
@@ -33,6 +33,7 @@
 #include "netcomms.h"
 #include "etsili_core.h"
 #include "intercept.h"
+#include "internetaccess.h"
 
 enum {
     OPENLI_EXPORT_HALT_WORKER = 1,
@@ -92,13 +93,15 @@ typedef struct openli_ipiri_job {
     char *liid;
     uint32_t cin;
     char *username;
-    struct sockaddr_storage assignedip;
-    int ipfamily;
+
+    internetaccess_ip_t *assignedips;
+    uint8_t ipcount;
+    uint8_t ipversioning;
+
     struct timeval sessionstartts;
     internet_access_method_t access_tech;
     uint8_t special;
     uint8_t ipassignmentmethod;
-    uint8_t assignedip_prefixbits;
     etsili_iri_type_t iritype;
     etsili_generic_t *customparams;
 

--- a/src/collector/collector_push_messaging.c
+++ b/src/collector/collector_push_messaging.c
@@ -52,6 +52,118 @@ static int remove_rtp_stream(colthread_local_t *loc, char *rtpstreamkey) {
     return 1;
 }
 
+int add_iprange_to_patricia(patricia_tree_t *ptree, char *iprangestr,
+        intercept_common_t *common, uint32_t cin) {
+
+    patricia_node_t *node = NULL;
+    liid_set_t **all, *found;
+    prefix_t *prefix = NULL;
+
+    prefix = ascii2prefix(0, iprangestr);
+    if (prefix == NULL) {
+        logger(LOG_INFO,
+                "OpenLI: error converting %s into a valid IP prefix",
+                iprangestr);
+        return -1;
+    }
+
+    node = patricia_lookup(ptree, prefix);
+
+    if (!node) {
+        logger(LOG_INFO,
+                "OpenLI: error while adding IP prefix %s to LIID %s",
+                iprangestr, common->liid);
+        free(prefix);
+        return -1;
+    }
+
+    all = (liid_set_t **)&(node->data);
+    if (*all != NULL) {
+        free(prefix);
+    } else {
+        prefix->ref_count --;
+    }
+
+    HASH_FIND(hh, *all, common->liid, common->liid_len, found);
+    if (found) {
+        return 0;
+    } else {
+        char key[128];
+
+        found = (liid_set_t *)malloc(sizeof(liid_set_t));
+        found->liid = strdup(common->liid);
+        found->cin = cin;
+
+        snprintf(key, 127, "%s-%u", found->liid, found->cin);
+        found->key = strdup(key);
+        found->keylen = strlen(found->key);
+
+
+        HASH_ADD_KEYPTR(hh, *all, found->liid, strlen(found->liid), found);
+        /*
+        logger(LOG_INFO,
+                "OpenLI: added LIID %s:%u to prefix %s (%d refs total)",
+                common->liid, cin, iprangestr, HASH_CNT(hh, *all));
+        */
+    }
+    return 1;
+
+}
+
+void remove_iprange_from_patricia(patricia_tree_t *ptree, char *iprangestr,
+        intercept_common_t *common) {
+
+    patricia_node_t *node = NULL;
+    prefix_t *prefix = NULL;
+    liid_set_t **all, *found;
+    liid_set_t *a, *b;
+
+    prefix = ascii2prefix(0, iprangestr);
+    if (prefix == NULL) {
+        logger(LOG_INFO,
+                "OpenLI: error converting %s into a valid IP prefix",
+                iprangestr);
+        goto bailremoverange;
+    }
+
+    node = patricia_search_exact(ptree, prefix);
+
+    if (!node) {
+        logger(LOG_INFO,
+                "OpenLI: supposed to remove IP prefix %s for LIID %s but no such prefix exists in the tree.",
+                iprangestr, common->liid);
+        goto bailremoverange;
+    }
+
+    all = (liid_set_t **)&(node->data);
+    HASH_FIND(hh, *all, common->liid, common->liid_len, found);
+    if (!found) {
+        logger(LOG_INFO,
+                "OpenLI: supposed to remove IP prefix %s for LIID %s but the LIID is not associated with that prefix.",
+                iprangestr, common->liid);
+        goto bailremoverange;
+    }
+
+    HASH_DELETE(hh, *all, found);
+    /*
+    logger(LOG_INFO,
+            "OpenLI: removed LIID %s from prefix %s (%d refs remaining)",
+            common->liid, iprangestr, HASH_CNT(hh, *all));
+    */
+    if (*all == NULL) {
+        patricia_remove(ptree, node);
+    }
+    free(found->liid);
+    free(found->key);
+    free(found);
+
+bailremoverange:
+    if (prefix) {
+        free(prefix);
+    }
+    return;
+}
+
 static int add_ipv4_intercept(colthread_local_t *loc, ipsession_t *sess) {
 
     uint32_t v4addr;
@@ -91,10 +203,11 @@ static int add_ipv4_intercept(colthread_local_t *loc, ipsession_t *sess) {
 
 static int add_ipv6_intercept(colthread_local_t *loc, ipsession_t *sess) {
 
-    uint8_t *v6addr;
     struct sockaddr_in6 *sin6;
     ipv6_target_t *tgt;
     ipsession_t *check;
+    char prefixstr[100];
+    char inet[INET6_ADDRSTRLEN];
 
     sin6 = (struct sockaddr_in6 *)(sess->targetip);
     if (sin6 == NULL) {
@@ -102,18 +215,32 @@ static int add_ipv6_intercept(colthread_local_t *loc, ipsession_t *sess) {
         return -1;
     }
 
-    v6addr = sin6->sin6_addr.s6_addr;
+    if (inet_ntop(AF_INET6, &(sin6->sin6_addr), inet, INET6_ADDRSTRLEN)
+            == NULL) {
+        logger(LOG_INFO, "OpenLI: IPv6 intercept prefix does not contain a valid IPv6 address");
+        return -1;
+    }
 
-    HASH_FIND(hh, loc->activeipv6intercepts, v6addr, 16, tgt);
+    snprintf(prefixstr, 100, "%s/%u", inet, sess->prefixlen);
+
+    if (add_iprange_to_patricia(loc->dynamicv6ranges, prefixstr,
+            &(sess->common), sess->cin) < 0) {
+        return -1;
+    }
+
+    HASH_FIND(hh, loc->activeipv6intercepts, prefixstr, strlen(prefixstr), tgt);
     if (tgt == NULL) {
         tgt = (ipv6_target_t *)malloc(sizeof(ipv6_target_t));
         if (!tgt) {
             logger(LOG_INFO, "OpenLI: ran out of memory while adding IPv6 intercept address.");
             return -1;
         }
-        memcpy(tgt->address, v6addr, 16);
+        memcpy(tgt->address, sin6->sin6_addr.s6_addr, 16);
+        tgt->prefixlen = sess->prefixlen;
+        tgt->prefixstr = strdup(prefixstr);
         tgt->intercepts = NULL;
-        HASH_ADD_KEYPTR(hh, loc->activeipv6intercepts, tgt->address, 16, tgt);
+        HASH_ADD_KEYPTR(hh, loc->activeipv6intercepts, tgt->prefixstr,
+                strlen(tgt->prefixstr), tgt);
     }
 
     HASH_FIND(hh, tgt->intercepts, sess->streamkey, strlen(sess->streamkey),
@@ -165,8 +292,9 @@ static int remove_ipv6_intercept(colthread_local_t *loc, ipsession_t *torem) {
 
     ipv6_target_t *v6;
     struct sockaddr_in6 *sin6;
-    uint8_t *v6addr;
     ipsession_t *found;
+    char prefixstr[100];
+    char inet[INET6_ADDRSTRLEN];
 
     sin6 = (struct sockaddr_in6 *)(torem->targetip);
     if (sin6 == NULL) {
@@ -174,8 +302,15 @@ static int remove_ipv6_intercept(colthread_local_t *loc, ipsession_t *torem) {
         return -1;
     }
 
-    v6addr = sin6->sin6_addr.s6_addr;
-    HASH_FIND(hh, loc->activeipv6intercepts, v6addr, 16, v6);
+    if (inet_ntop(AF_INET6, &(sin6->sin6_addr), inet, INET6_ADDRSTRLEN)
+            == NULL) {
+        logger(LOG_INFO, "OpenLI: IPv6 intercept prefix does not contain a valid IPv6 address");
+        return -1;
+    }
+
+    snprintf(prefixstr, 100, "%s/%u", inet, torem->prefixlen);
+
+    HASH_FIND(hh, loc->activeipv6intercepts, prefixstr, strlen(prefixstr), v6);
     if (!v6) {
         return 0;
     }
@@ -186,11 +321,15 @@ static int remove_ipv6_intercept(colthread_local_t *loc, ipsession_t *torem) {
         return 0;
     }
 
+    remove_iprange_from_patricia(loc->dynamicv6ranges, prefixstr,
+            &(found->common));
+
     HASH_DELETE(hh, v6->intercepts, found);
     free_single_ipsession(found);
 
     if (HASH_CNT(hh, v6->intercepts) == 0) {
         HASH_DELETE(hh, loc->activeipv6intercepts, v6);
+        free(v6->prefixstr);
         free(v6);
     }
 
@@ -251,9 +390,13 @@ void handle_halt_mirror_intercept(libtrace_thread_t *t,
     }
 
     HASH_DELETE(hh, parent->intercepts, found);
+    free_single_vendmirror_intercept(found);
+
     if (HASH_CNT(hh, parent->intercepts) == 0) {
         HASH_DELETE(hh, loc->activemirrorintercepts, parent);
+        free(parent);
     }
+    free_single_vendmirror_intercept(vmi);
 }
 
 void handle_push_ipintercept(libtrace_thread_t *t, colthread_local_t *loc,
@@ -408,74 +551,31 @@ void handle_remove_coreserver(libtrace_thread_t *t, colthread_local_t *loc,
 void handle_iprange(libtrace_thread_t *t, colthread_local_t *loc,
         staticipsession_t *ipr) {
 
-    patricia_node_t *node = NULL;
-    liid_set_t **all, *found;
-    prefix_t *prefix = NULL;
     staticipsession_t *newsess, *ipr_exist;
+    patricia_tree_t *ptree = NULL;
 
-    prefix = ascii2prefix(0, ipr->rangestr);
-    if (prefix == NULL) {
-        logger(LOG_INFO,
-                "OpenLI: error converting %s into a valid IP prefix in thread %d",
-                ipr->rangestr, trace_get_perpkt_thread_id(t));
+    if (strchr(ipr->rangestr, ':')) {
+        ptree = loc->staticv6ranges;
+    } else {
+        ptree = loc->staticv4ranges;
+    }
+
+    if (add_iprange_to_patricia(ptree, ipr->rangestr, &(ipr->common),
+            ipr->cin) <= 0) {
+
         free_single_staticipsession(ipr);
         return;
     }
 
-    if (prefix->family == AF_INET) {
-        node = patricia_lookup(loc->staticv4ranges, prefix);
-    } else if (prefix->family == AF_INET6) {
-        node = patricia_lookup(loc->staticv6ranges, prefix);
-    }
-
-    if (!node) {
-        logger(LOG_INFO,
-                "OpenLI: error while adding static IP prefix %s to LIID %s for thread %d",
-                ipr->rangestr, ipr->common.liid, trace_get_perpkt_thread_id(t));
-        free_single_staticipsession(ipr);
-        free(prefix);
-        return;
-    }
-
-    all = (liid_set_t **)&(node->data);
-    if (*all != NULL) {
-        free(prefix);
+    HASH_FIND(hh, loc->activestaticintercepts, ipr->key,
+            strlen(ipr->key), ipr_exist);
+    if (!ipr_exist) {
+        ipr->references = 1;
+        HASH_ADD_KEYPTR(hh, loc->activestaticintercepts, ipr->key,
+                strlen(ipr->key), ipr);
     } else {
-        prefix->ref_count --;
-    }
-
-    HASH_FIND(hh, *all, ipr->common.liid, ipr->common.liid_len, found);
-    if (found) {
+        ipr_exist->references ++;
         free_single_staticipsession(ipr);
-    } else {
-        char key[128];
-
-        found = (liid_set_t *)malloc(sizeof(liid_set_t));
-        found->liid = strdup(ipr->common.liid);
-        found->cin = ipr->cin;
-
-        snprintf(key, 127, "%s-%u", found->liid, found->cin);
-        found->key = strdup(key);
-        found->keylen = strlen(found->key);
-
-
-        HASH_ADD_KEYPTR(hh, *all, found->liid, strlen(found->liid), found);
-        /*
-        logger(LOG_INFO,
-                "OpenLI: added LIID %s:%u to prefix %s (%d refs total)",
-                ipr->common.liid, ipr->cin, ipr->rangestr, HASH_CNT(hh, *all));
-        */
-
-        HASH_FIND(hh, loc->activestaticintercepts, ipr->key,
-                strlen(ipr->key), ipr_exist);
-        if (!ipr_exist) {
-            ipr->references = 1;
-            HASH_ADD_KEYPTR(hh, loc->activestaticintercepts, ipr->key,
-                    strlen(ipr->key), ipr);
-        } else {
-            ipr_exist->references ++;
-            free_single_staticipsession(ipr);
-        }
     }
 }
 
@@ -564,41 +664,16 @@ bailmodrange:
 void handle_remove_iprange(libtrace_thread_t *t, colthread_local_t *loc,
         staticipsession_t *ipr) {
 
-    patricia_node_t *node = NULL;
-    prefix_t *prefix;
-    liid_set_t **all, *found;
-    liid_set_t *a, *b;
     staticipsession_t *sessrec;
+    patricia_tree_t *ptree;
 
-    prefix = ascii2prefix(0, ipr->rangestr);
-    if (prefix == NULL) {
-        logger(LOG_INFO,
-                "OpenLI: error converting %s into a valid IP prefix in thread %d",
-                ipr->rangestr, trace_get_perpkt_thread_id(t));
-        goto bailremoverange;
+    if (strchr(ipr->rangestr, ':')) {
+        ptree = loc->staticv6ranges;
+    } else {
+        ptree = loc->staticv4ranges;
     }
 
-    if (prefix->family == AF_INET) {
-        node = patricia_search_exact(loc->staticv4ranges, prefix);
-    } else if (prefix->family == AF_INET6) {
-        node = patricia_search_exact(loc->staticv6ranges, prefix);
-    }
-
-    if (!node) {
-        logger(LOG_INFO,
-                "OpenLI: thread %d was supposed to remove IP prefix %s for LIID %s but no such prefix exists in the tree.",
-                trace_get_perpkt_thread_id(t), ipr->rangestr, ipr->common.liid);
-        goto bailremoverange;
-    }
-
-    all = (liid_set_t **)&(node->data);
-    HASH_FIND(hh, *all, ipr->common.liid, ipr->common.liid_len, found);
-    if (!found) {
-        logger(LOG_INFO,
-                "OpenLI: thread %d was supposed to remove IP prefix %s for LIID %s but the LIID is not associated with that prefix.",
-                trace_get_perpkt_thread_id(t), ipr->rangestr, ipr->common.liid);
-        goto bailremoverange;
-    }
+    remove_iprange_from_patricia(ptree, ipr->rangestr, &(ipr->common));
 
     HASH_FIND(hh, loc->activestaticintercepts, ipr->key, strlen(ipr->key),
             sessrec);
@@ -614,29 +689,6 @@ void handle_remove_iprange(libtrace_thread_t *t, colthread_local_t *loc,
                 ipr->key);
     }
 
-    HASH_DELETE(hh, *all, found);
-    /*
-    logger(LOG_INFO,
-            "OpenLI: removed LIID %s from prefix %s (%d refs remaining)",
-            ipr->common.liid, ipr->rangestr, HASH_CNT(hh, *all));
-    */
-    if (*all == NULL) {
-        if (prefix->family == AF_INET) {
-            patricia_remove(loc->staticv4ranges, node);
-        } else {
-            patricia_remove(loc->staticv6ranges, node);
-        }
-    }
-    free(found->liid);
-    free(found->key);
-    free(found);
-
-
-
-bailremoverange:
-    if (prefix) {
-        free(prefix);
-    }
     free_single_staticipsession(ipr);
     return;
 }

--- a/src/collector/internetaccess.h
+++ b/src/collector/internetaccess.h
@@ -35,6 +35,8 @@
 #include "etsili_core.h"
 #include "intercept.h"
 
+#define SESSION_IP_INCR (5)
+
 enum {
     ACCESS_RADIUS,
     ACCESS_GTP,
@@ -72,6 +74,13 @@ typedef enum {
     USER_IDENT_MAX
 } user_identity_method_t;
 
+typedef enum {
+    SESSION_IP_VERSION_NONE,
+    SESSION_IP_VERSION_V4,
+    SESSION_IP_VERSION_V6,
+    SESSION_IP_VERSION_DUAL,
+} session_ipversion_t;
+
 typedef struct access_plugin access_plugin_t;
 typedef struct internet_user internet_user_t;
 typedef struct access_session access_session_t;
@@ -98,7 +107,10 @@ typedef struct ip_to_session {
 
 struct access_session {
 
-    internetaccess_ip_t sessionip;
+    internetaccess_ip_t *sessionips;
+    uint8_t sessipcount;
+    session_ipversion_t sessipversion;
+
     access_plugin_t *plugin;
     void *sessionid;
     void *statedata;
@@ -179,6 +191,8 @@ access_plugin_t *get_gtp_access_plugin(void);
 
 access_session_t *create_access_session(access_plugin_t *p,
         char *idstr, int idstr_len);
+void add_new_session_ip(access_session_t *sess, void *att_val,
+        int family, uint8_t pfxbits);
 
 const char *accesstype_to_string(internet_access_method_t am);
 

--- a/src/collector/ipcc.c
+++ b/src/collector/ipcc.c
@@ -206,14 +206,58 @@ static inline int lookup_static_ranges(struct sockaddr *cmp,
     return matched;
 }
 
+static void singlev6_conn_contents(struct sockaddr_in6 *cmp,
+        colthread_local_t *loc, int *matched, libtrace_packet_t *pkt) {
+
+    patricia_node_t *pnode = NULL;
+    prefix_t prefix;
+    openli_export_recv_t *msg;
+    ipv6_target_t *tgt;
+    ipsession_t *sess, *tmp;
+
+    memset(&prefix, 0, sizeof(prefix_t));
+    memcpy(&(prefix.add.sin6), &(cmp->sin6_addr), 16);
+    prefix.bitlen = 128;
+    prefix.family = AF_INET6;
+    prefix.ref_count = 0;
+
+    pnode = patricia_search_best2(loc->dynamicv6ranges, &prefix, 1);
+
+    while (pnode) {
+        liid_set_t **all, *sliid, *tmp2;
+
+        all = (liid_set_t **)(&(pnode->data));
+        HASH_ITER(hh, *all, sliid, tmp2) {
+            HASH_FIND(hh, loc->activeipv6intercepts, sliid->key, sliid->keylen,
+                    tgt);
+            if (!tgt) {
+                logger(LOG_INFO,
+                        "OpenLI: matched an IPv6 range for intercept %s but this intercept is not present in activeipv6intercepts?",
+                        sliid->key);
+            } else {
+                HASH_ITER(hh, tgt->intercepts, sess, tmp) {
+                    *matched ++;
+                    msg = create_ipcc_job(sess->cin, sess->common.liid,
+                            sess->common.destid, pkt, 0);
+                    if (sess->accesstype == INTERNET_ACCESS_TYPE_MOBILE && msg)
+                    {
+                        msg->type = OPENLI_EXPORT_UMTSCC;
+                    }
+                    if (msg != NULL) {
+                        publish_openli_msg(loc->zmq_pubsocks[0], msg);  //FIXME
+                    }
+                }
+            }
+        }
+        pnode = pnode->parent;
+    }
+}
+
 int ipv6_comm_contents(libtrace_packet_t *pkt, packet_info_t *pinfo,
         libtrace_ip6_t *ip, uint32_t rem, colthread_local_t *loc) {
 
-    struct sockaddr_in6 *intaddr, *cmp;
-    openli_export_recv_t *msg;
+    struct sockaddr_in6 *cmp;
     int matched = 0, queueused = 0;
-    ipv6_target_t *tgt;
-    ipsession_t *sess, *tmp;
 
     if (rem < sizeof(libtrace_ip6_t)) {
         /* Truncated IP header */
@@ -226,44 +270,10 @@ int ipv6_comm_contents(libtrace_packet_t *pkt, packet_info_t *pinfo,
      */
 
     cmp = (struct sockaddr_in6 *)(&pinfo->srcip);
-    HASH_FIND(hh, loc->activeipv6intercepts, &(cmp->sin6_addr.s6_addr),
-            sizeof(cmp->sin6_addr.s6_addr), tgt);
-
-    if (tgt) {
-        HASH_ITER(hh, tgt->intercepts, sess, tmp) {
-            matched ++;
-            msg = create_ipcc_job(sess->cin, sess->common.liid,
-                    sess->common.destid, pkt, 0);
-            if (sess->accesstype == INTERNET_ACCESS_TYPE_MOBILE && msg) {
-                msg->type = OPENLI_EXPORT_UMTSCC;
-            }
-            if (msg != NULL) {
-                publish_openli_msg(loc->zmq_pubsocks[0], msg);  //FIXME
-            }
-        }
-    }
+    singlev6_conn_contents(cmp, loc, &matched, pkt);
 
     cmp = (struct sockaddr_in6 *)(&pinfo->destip);
-    HASH_FIND(hh, loc->activeipv6intercepts, &(cmp->sin6_addr.s6_addr),
-            sizeof(cmp->sin6_addr.s6_addr), tgt);
-
-    if (tgt) {
-        HASH_ITER(hh, tgt->intercepts, sess, tmp) {
-            matched ++;
-            msg = create_ipcc_job(sess->cin, sess->common.liid,
-                    sess->common.destid, pkt, 1);
-            if (sess->accesstype == INTERNET_ACCESS_TYPE_MOBILE && msg) {
-                msg->type = OPENLI_EXPORT_UMTSCC;
-            }
-            if (msg != NULL) {
-                publish_openli_msg(loc->zmq_pubsocks[0], msg);  //FIXME
-            }
-        }
-    }
-
-    if (loc->staticv6ranges == NULL) {
-        goto ipv6ccdone;
-    }
+    singlev6_conn_contents(cmp, loc, &matched, pkt);
 
     matched += lookup_static_ranges((struct sockaddr *)(&pinfo->srcip),
             AF_INET6, pkt, 0, loc);

--- a/src/etsili_core.c
+++ b/src/etsili_core.c
@@ -288,6 +288,19 @@ static inline void encode_ipiri_id(wandder_encoder_t *encoder,
     wandder_encode_endseq(encoder);
 }
 
+static inline void encode_other_targets(wandder_encoder_t *encoder,
+        etsili_other_targets_t *others) {
+
+    int i;
+
+    ENC_CSEQUENCE(encoder, 0);
+    for (i = 0; i < others->count; i++) {
+        encode_ipaddress(encoder, &(others->targets[i]));
+    }
+    END_ENCODED_SEQUENCE(encoder, 1);
+
+}
+
 static int sort_etsili_generic(etsili_generic_t *a, etsili_generic_t *b) {
 
     if (a->itemnum < b->itemnum) {
@@ -629,7 +642,10 @@ static inline void encode_ipiri_body(wandder_encoder_t *encoder,
                 break;
 
             case IPIRI_CONTENTS_OTHER_TARGET_IDENTIFIERS:
-                /* TODO */
+                ENC_CSEQUENCE(encoder, p->itemnum);
+                encode_other_targets(encoder,
+                        (etsili_other_targets_t *)(p->itemptr));
+                END_ENCODED_SEQUENCE(encoder, 1);
                 break;
 
             case IPIRI_CONTENTS_POP_PORTNUMBER:

--- a/src/etsili_core.h
+++ b/src/etsili_core.h
@@ -80,6 +80,13 @@ typedef struct etsili_ipaddress {
     uint8_t *ipvalue;
 } etsili_ipaddress_t;
 
+typedef struct etsili_other_targets {
+
+    uint8_t count;
+    uint8_t alloced;
+    etsili_ipaddress_t *targets;
+} etsili_other_targets_t;
+
 typedef enum {
     ETSILI_IRI_NONE = 0,
     ETSILI_IRI_BEGIN = 1,

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -24,6 +24,7 @@
  *
  */
 
+#include "util.h"
 #include "logger.h"
 #include "intercept.h"
 
@@ -395,6 +396,7 @@ void free_all_vendmirror_intercepts(vendmirror_intercept_list_t **jmints) {
             free_single_vendmirror_intercept(jm);
         }
         HASH_DELETE(hh, *jmints, parent);
+        free(parent);
     }
 }
 
@@ -444,7 +446,7 @@ void free_all_staticipsessions(staticipsession_t **statintercepts) {
 }
 
 ipsession_t *create_ipsession(ipintercept_t *ipint, uint32_t cin,
-        int ipfamily, struct sockaddr *assignedip) {
+        int ipfamily, struct sockaddr *assignedip, uint8_t prefixlen) {
 
     ipsession_t *ipsess;
 
@@ -456,6 +458,7 @@ ipsession_t *create_ipsession(ipintercept_t *ipint, uint32_t cin,
     ipsess->nextseqno = 0;
     ipsess->cin = cin;
     ipsess->ai_family = ipfamily;
+    ipsess->prefixlen = prefixlen;
     ipsess->targetip = (struct sockaddr_storage *)(malloc(
             sizeof(struct sockaddr_storage)));
     if (!ipsess->targetip) {
@@ -474,6 +477,7 @@ ipsession_t *create_ipsession(ipintercept_t *ipint, uint32_t cin,
         return NULL;
     }
     snprintf(ipsess->streamkey, 256, "%s-%u", ipint->common.liid, cin);
+
     return ipsess;
 }
 

--- a/src/intercept.h
+++ b/src/intercept.h
@@ -212,6 +212,7 @@ struct ipsession {
     uint32_t cin;
     int ai_family;
     struct sockaddr_storage *targetip;
+    uint8_t prefixlen;
     uint32_t nextseqno;
     internet_access_method_t accesstype;
 
@@ -279,7 +280,7 @@ rtpstreaminf_t *create_rtpstream(voipintercept_t *vint, uint32_t cin);
 rtpstreaminf_t *deep_copy_rtpstream(rtpstreaminf_t *rtp);
 
 ipsession_t *create_ipsession(ipintercept_t *ipint, uint32_t cin,
-        int ipfamily, struct sockaddr *assignedip);
+        int ipfamily, struct sockaddr *assignedip, uint8_t prefixlen);
 
 vendmirror_intercept_t *create_vendmirror_intercept(ipintercept_t *ipint);
 


### PR DESCRIPTION
 * A session can now have multiple IP addresses, and these
   addresses can be a mix of v4 and v6.
 * Multi-address session IRIs will now include all addresses
   using an appropriate combination of targetIPAddress,
   additionalIPAddress, and otherTargetIdentifiers -- the latter
   is somewhat untested due to a lack of example traces.
 * The target address for an IPv6 dynamic session is now able to
   be expressed as a prefix, rather than a single address. This
   means we can properly intercept user traffic where the user has
   been delegated a /56 or /64. Again, needs some more testing
   with practical examples.
 * Fixed a few minor memory leaks uncovered while testing the
   fixes with valgrind.