### PR TITLE
Fix buggy behaviour when components disconnect and reconnect

### DIFF
--- a/src/collector/collector_forwarder.c
+++ b/src/collector/collector_forwarder.c
@@ -615,7 +615,7 @@ static void connect_export_targets(forwarding_thread_data_t *fwd) {
 
 static int drain_incoming_etsi(forwarding_thread_data_t *fwd) {
 
-    int x;
+    int x, encoders_over = 0;
     openli_encoded_result_t res;
 
     do {
@@ -625,11 +625,17 @@ static int drain_incoming_etsi(forwarding_thread_data_t *fwd) {
             return -1;
         }
 
-        if (x <= 0) {
-            break;
+        if (x < 0) {
+            continue;
         }
+
+        if (res.liid == NULL && res.destid == 0) {
+            logger(LOG_INFO, "encoder %d has ceased encoding", encoders_over);
+            encoders_over ++;
+        }
+
         free_encoded_result(&res);
-    } while (x > 0);
+    } while (encoders_over < fwd->encoders);
 
     return 1;
 }

--- a/src/collector/collector_forwarder.c
+++ b/src/collector/collector_forwarder.c
@@ -125,6 +125,7 @@ static int add_new_destination(forwarding_thread_data_t *fwd,
                     strcmp(found->portstr, msg->data.med.portstr) != 0) {
                 /* Mediator has changed IP or port */
                 logger(LOG_INFO, "OpenLI: mediator %u has changed location from %s:%s to %s:%s",
+                        found->mediatorid,
                         found->ipstr, found->portstr, msg->data.med.ipstr,
                         msg->data.med.portstr);
                 free(found->ipstr);

--- a/src/collector/collector_publish.c
+++ b/src/collector/collector_publish.c
@@ -119,6 +119,12 @@ openli_export_recv_t *create_ipcc_job(uint32_t cin, char *liid,
         msg->data.ipcc.liid = realloc(msg->data.ipcc.liid, x);
         msg->data.ipcc.liidalloc = x;
     }
+    if (msg->data.ipcc.liid == NULL) {
+        msg->data.ipcc.liidalloc = 0;
+        free(msg);
+        return NULL;
+    }
+
     memcpy(msg->data.ipcc.liid, liid, liidlen);
     msg->data.ipcc.liid[liidlen] = '\0';
 
@@ -132,6 +138,11 @@ openli_export_recv_t *create_ipcc_job(uint32_t cin, char *liid,
         msg->data.ipcc.ipcalloc = x;
     }
 
+    if (msg->data.ipcc.ipcontent == NULL) {
+        msg->data.ipcc.ipcalloc = 0;
+        free(msg);
+        return NULL;
+    }
     memcpy(msg->data.ipcc.ipcontent, l3, rem);
     msg->data.ipcc.ipclen = rem;
     msg->data.ipcc.cin = cin;

--- a/src/collector/collector_seqtracker.c
+++ b/src/collector/collector_seqtracker.c
@@ -492,7 +492,7 @@ void *start_seqtracker_thread(void *data) {
     char sockname[128];
     seqtracker_thread_data_t *seqdata = (seqtracker_thread_data_t *)data;
     openli_export_recv_t *job = NULL;
-    int x, zero = 0, large=1000000;
+    int x, zero = 0, large=1000000, sndtimeo=1000;
     exporter_intercept_state_t *intstate, *tmpexp;
 
     seqdata->zmq_recvpublished = zmq_socket(seqdata->zmq_ctxt, ZMQ_PULL);
@@ -515,12 +515,6 @@ void *start_seqtracker_thread(void *data) {
 
     seqdata->zmq_pushjobsock = zmq_socket(seqdata->zmq_ctxt, ZMQ_PUSH);
     snprintf(sockname, 128, "inproc://openliseqpush-%d", seqdata->trackerid);
-    if (zmq_bind(seqdata->zmq_pushjobsock, sockname) < 0) {
-        logger(LOG_INFO,
-                "OpenLI: tracker thread %d failed to bind to push zmq: %s",
-                seqdata->trackerid, strerror(errno));
-        goto haltseqtracker;
-    }
     if (zmq_setsockopt(seqdata->zmq_pushjobsock, ZMQ_LINGER, &zero,
                 sizeof(zero)) != 0) {
         logger(LOG_INFO,
@@ -532,6 +526,19 @@ void *start_seqtracker_thread(void *data) {
                 sizeof(large)) != 0) {
         logger(LOG_INFO,
                 "OpenLI: tracker thread %d failed to configure push zmq: %s",
+                seqdata->trackerid, strerror(errno));
+        goto haltseqtracker;
+    }
+    if (zmq_setsockopt(seqdata->zmq_pushjobsock, ZMQ_SNDTIMEO, &sndtimeo,
+                sizeof(sndtimeo)) != 0) {
+        logger(LOG_INFO,
+                "OpenLI: tracker thread %d failed to configure push zmq: %s",
+                seqdata->trackerid, strerror(errno));
+        goto haltseqtracker;
+    }
+    if (zmq_bind(seqdata->zmq_pushjobsock, sockname) < 0) {
+        logger(LOG_INFO,
+                "OpenLI: tracker thread %d failed to bind to push zmq: %s",
                 seqdata->trackerid, strerror(errno));
         goto haltseqtracker;
     }

--- a/src/collector/collector_sync.c
+++ b/src/collector/collector_sync.c
@@ -1253,7 +1253,7 @@ static int new_ipintercept(collector_sync_t *sync, uint8_t *intmsg,
                 x->accesstype = cept->accesstype;
             }
             x->awaitingconfirm = 0;
-            free(cept);
+            free_single_ipintercept(cept);
             /* our collector threads should already know about this intercept */
             return 1;
         }
@@ -1543,6 +1543,9 @@ int sync_connect_provisioner(collector_sync_t *sync, SSL_CTX *ctx) {
         fd_set_block(sockfd);
         //collector cannt do anything untill it has instructions from provisioner so blocking is fine
 
+        if (sync->ssl) {
+            SSL_free(sync->ssl);
+        }
         sync->ssl = SSL_new(ctx);
         SSL_set_fd(sync->ssl, sockfd);
         SSL_set_connect_state(sync->ssl); //set client mode

--- a/src/collector/encoder_worker.c
+++ b/src/collector/encoder_worker.c
@@ -180,6 +180,10 @@ void destroy_encoder_worker(openli_encoder_t *enc) {
 
     for (i = 0; i < enc->forwarders; i++) {
         if (enc->zmq_pushresults[i]) {
+            openli_encoded_result_t final;
+
+            memset(&final, 0, sizeof(final));
+            zmq_send(enc->zmq_pushresults[i], &final, sizeof(final), 0);
             zmq_close(enc->zmq_pushresults[i]);
         }
     }

--- a/src/collector/encoder_worker.c
+++ b/src/collector/encoder_worker.c
@@ -149,7 +149,7 @@ void destroy_encoder_worker(openli_encoder_t *enc) {
     for (i = 0; i < enc->seqtrackers; i++) {
         do {
             x = zmq_recv(enc->zmq_recvjobs[i], &job,
-                    sizeof(openli_encoding_job_t), ZMQ_DONTWAIT);
+                    sizeof(openli_encoding_job_t), 0);
             if (x < 0) {
                 if (errno == EAGAIN) {
                     continue;
@@ -161,6 +161,12 @@ void destroy_encoder_worker(openli_encoder_t *enc) {
                 free_published_message(job.origreq);
             } else {
                 free(job.origreq);
+            }
+            if (job.liid) {
+                free(job.liid);
+            }
+            if (job.cinstr) {
+                free(job.cinstr);
             }
             drained ++;
 

--- a/src/provisioner/hup_reload.c
+++ b/src/provisioner/hup_reload.c
@@ -584,7 +584,8 @@ static inline int reload_mediator_socket_config(provision_state_t *currstate,
     if (strcmp(newstate->mediateaddr, currstate->mediateaddr) != 0 ||
             strcmp(newstate->mediateport, currstate->mediateport) != 0) {
 
-        free_all_mediators(currstate->epoll_fd, &(currstate->mediators));
+        free_all_mediators(currstate->epoll_fd, &(currstate->mediators),
+                &(currstate->knownmeds));
 
         if (epoll_ctl(currstate->epoll_fd, EPOLL_CTL_DEL,
                 currstate->mediatorfd->fd, &ev) == -1) {
@@ -743,7 +744,8 @@ int reload_provisioner_config(provision_state_t *currstate) {
 
     if (tlschanged != 0) {
         if (!mediatorchanged) {
-            free_all_mediators(currstate->epoll_fd, &(currstate->mediators));
+            free_all_mediators(currstate->epoll_fd, &(currstate->mediators),
+                    &(currstate->knownmeds));
             mediatorchanged = 1;
         }
         if (!clientchanged) {

--- a/src/provisioner/provisioner.c
+++ b/src/provisioner/provisioner.c
@@ -378,7 +378,7 @@ static int announce_mediator_withdraw(provision_state_t *state,
 }
 
 static int add_collector_to_hashmap(provision_state_t *state,
-        prov_client_t *client) {
+        prov_client_t *client, prov_sock_state_t *cs) {
 
     prov_collector_t *col;
 
@@ -394,6 +394,7 @@ static int add_collector_to_hashmap(provision_state_t *state,
         logger(LOG_INFO,
                 "OpenLI provisioner: collector %s is now active",
                 client->identifier);
+        cs->parent = (void *)col;
     } else {
         /* Can probably get away with not caring if we see a duplicate? */
     }
@@ -1004,7 +1005,7 @@ static int receive_collector(provision_state_t *state, prov_epoll_ev_t *pev) {
                 }
                 cs->trusted = 1;
                 justauthed = 1;
-                add_collector_to_hashmap(state, pev->client);
+                add_collector_to_hashmap(state, pev->client, cs);
                 break;
             default:
                 if (cs->log_allowed) {

--- a/src/provisioner/provisioner.c
+++ b/src/provisioner/provisioner.c
@@ -215,6 +215,8 @@ int init_prov_state(provision_state_t *state, char *configfile) {
     state->epoll_fd = epoll_create1(0);
     state->mediators = NULL;
     state->collectors = NULL;
+    state->pendingclients = NULL;
+    state->knownmeds = NULL;
 
     /* Three listening sockets
      *
@@ -282,14 +284,136 @@ int init_prov_state(provision_state_t *state, char *configfile) {
     return 0;
 }
 
+static int announce_mediator(provision_state_t *state,
+        prov_mediator_t *med) {
+
+    prov_collector_t *col, *coltmp;
+
+    HASH_ITER(hh, state->collectors, col, coltmp) {
+        prov_sock_state_t *cs = (prov_sock_state_t *)(col->client->state);
+
+        if (cs == NULL) {
+            continue;
+        }
+
+        if (col->client->commev == NULL ||
+                col->client->commev->fdtype != PROV_EPOLL_COLLECTOR) {
+            continue;
+        }
+
+        if (col->client->commev->fd == -1) {
+            continue;
+        }
+
+        if (cs->trusted == 0) {
+            continue;
+        }
+
+        if (push_mediator_onto_net_buffer(cs->outgoing, med->details) < 0) {
+            if (cs->log_allowed) {
+                logger(LOG_INFO,
+                    "OpenLI provisioner: error pushing mediator %s:%s onto buffer for writing to collector %s.",
+                    med->details->ipstr, med->details->portstr,
+                    col->identifier);
+            }
+            return -1;
+        }
+        if (enable_epoll_write(state, col->client->commev) == -1) {
+            if (cs->log_allowed) {
+                logger(LOG_INFO,
+                    "OpenLI provisioner: cannot enable epoll write event to transmit mediator update to collector %s -- %s.",
+                    col->identifier, strerror(errno));
+            }
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int announce_mediator_withdraw(provision_state_t *state,
+        prov_mediator_t *med) {
+
+    prov_collector_t *col, *coltmp;
+
+    HASH_ITER(hh, state->collectors, col, coltmp) {
+        prov_sock_state_t *cs = (prov_sock_state_t *)(col->client->state);
+
+        if (cs == NULL) {
+            continue;
+        }
+
+        if (col->client->commev == NULL ||
+                col->client->commev->fdtype != PROV_EPOLL_COLLECTOR) {
+            continue;
+        }
+
+        if (col->client->commev->fd == -1) {
+            continue;
+        }
+
+        if (cs->trusted == 0) {
+            continue;
+        }
+
+        if (push_mediator_withdraw_onto_net_buffer(cs->outgoing,
+                med->details) < 0) {
+            if (cs->log_allowed) {
+                logger(LOG_INFO,
+                        "OpenLI provisioner: error pushing mediator withdrawal %s:%s onto buffer for writing to collector %s.",
+                        med->details->ipstr, med->details->portstr,
+                        col->identifier);
+            }
+            return -1;
+        }
+        if (enable_epoll_write(state, col->client->commev) == -1) {
+            if (cs->log_allowed) {
+                logger(LOG_INFO,
+                    "OpenLI provisioner: cannot enable epoll write event to transmit mediator update to collector %s -- %s.",
+                    col->identifier, strerror(errno));
+            }
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int add_collector_to_hashmap(provision_state_t *state,
+        prov_client_t *client) {
+
+    prov_collector_t *col;
+
+    HASH_FIND(hh, state->collectors, client->identifier,
+            strlen(client->identifier), col);
+
+    if (!col) {
+        col = calloc(1, sizeof(prov_collector_t));
+        col->identifier = strdup(client->identifier);
+        col->client = client;
+        HASH_ADD_KEYPTR(hh, state->collectors, col->identifier,
+                strlen(col->identifier), col);
+        logger(LOG_INFO,
+                "OpenLI provisioner: collector %s is now active",
+                client->identifier);
+    } else {
+        /* Can probably get away with not caring if we see a duplicate? */
+    }
+
+    HASH_DELETE(hh, state->pendingclients, client);
+
+
+    return 0;
+}
+
 static int update_mediator_details(provision_state_t *state, uint8_t *medmsg,
-        uint16_t msglen, char *identifier) {
+        uint16_t msglen, prov_sock_state_t *cs, char *clientname) {
 
     openli_mediator_t *med = (openli_mediator_t *)malloc(
             sizeof(openli_mediator_t));
-    openli_mediator_t *prevmed = NULL;
-    prov_collector_t *col, *coltmp;
-    prov_mediator_t *provmed;
+    openli_mediator_t *tmp = NULL;
+    prov_client_t *pending;
+    mediator_address_t *knownaddr;
+    prov_mediator_t *provmed = NULL, *prevmed = NULL;
+    char identifier[1024];
     int ret = 0;
 
     if (decode_mediator_announcement(medmsg, msglen, med) == -1) {
@@ -299,99 +423,131 @@ static int update_mediator_details(provision_state_t *state, uint8_t *medmsg,
         return -1;
     }
 
-    /* Find the corresponding mediator in our mediator list */
-    HASH_FIND(hh, state->mediators, identifier, strlen(identifier), provmed);
+    HASH_FIND(hh, state->mediators, &(med->mediatorid), sizeof(med->mediatorid),
+            prevmed);
 
-    if (!provmed) {
-        free_openli_mediator(med);
-        return 0;
-    }
+    if (prevmed) {
 
-    if (provmed->details == NULL) {
-        provmed->details = med;
+        if (prevmed->mediatorid == med->mediatorid &&
+                strcmp(prevmed->details->ipstr, med->ipstr) == 0 &&
+                strcmp(prevmed->details->portstr, med->portstr) == 0) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: mediator %u has reconnected (%s:%s)",
+                    med->mediatorid, med->ipstr, med->portstr);
+
+            /* Don't need to inform collectors, they should reconnect on
+             * their own once the mediator starts listening.
+             */
+            free(med->ipstr);
+            free(med->portstr);
+            free(med);
+            return 0;
+        }
+
+        logger(LOG_INFO,
+                "OpenLI provisioner: replacing mediator %u (%s:%s) with %u (%s:%s)",
+                prevmed->mediatorid, prevmed->details->ipstr,
+                prevmed->details->portstr,
+                med->mediatorid, med->ipstr, med->portstr);
+
+        announce_mediator_withdraw(state, prevmed);
+        tmp = prevmed->details;
+        prevmed->details = med;
+        provmed = prevmed;
     } else {
-        prevmed = provmed->details;
+        HASH_FIND(hh, state->pendingclients, clientname, strlen(clientname),
+                pending);
+
+        if (!pending) {
+            logger(LOG_INFO,
+                    "OpenLI provisioner: received an announcement from mediator %u via %s, but this mediator is unknown to us?",
+                    med->mediatorid, clientname);
+            free(med->ipstr);
+            free(med->portstr);
+            free(med);
+            return -1;
+        }
+
+        provmed = calloc(1, sizeof(prov_mediator_t));
+        provmed->mediatorid = med->mediatorid;
         provmed->details = med;
+        provmed->client = pending;
+        HASH_DELETE(hh, state->pendingclients, pending);
+        HASH_ADD_KEYPTR(hh, state->mediators, &(provmed->mediatorid),
+                sizeof(provmed->mediatorid), provmed);
+        cs->parent = (void *)provmed;
     }
 
-    /* All collectors must now know about this mediator */
-    HASH_ITER(hh, state->collectors, col, coltmp) {
+    /* If another mediator is using the same IP + port as a previous one,
+     * we need to make sure collectors do not connect to that socket for
+     * the old mediator.
+     */
+    snprintf(identifier, 1024, "%s-%s", med->ipstr, med->portstr);
+    logger(LOG_INFO, "identifier is %s\n", identifier);
 
-        prov_sock_state_t *cs = (prov_sock_state_t *)(col->client.state);
+    HASH_FIND(hh, state->knownmeds, identifier, strlen(identifier), knownaddr);
+    if (!knownaddr) {
+        knownaddr = calloc(1, sizeof(mediator_address_t));
+        knownaddr->medid = provmed->mediatorid;
+        knownaddr->ipportstr = strdup(identifier);
 
-        if (cs == NULL) {
-            continue;
-        }
-
-        if (col->client.commev == NULL ||
-                col->client.commev->fdtype != PROV_EPOLL_COLLECTOR) {
-            continue;
-        }
-
-        if (col->client.commev->fd == -1) {
-            continue;
-        }
-
-        if (cs->trusted == 0) {
-            continue;
-        }
+        HASH_ADD_KEYPTR(hh, state->knownmeds, knownaddr->ipportstr,
+                strlen(knownaddr->ipportstr), knownaddr);
+    } else {
+        logger(LOG_INFO,
+                "OpenLI provisioner: duplicate use of %s by mediators %u and %u, removing %u",
+                identifier, knownaddr->medid, provmed->mediatorid,
+                knownaddr->medid);
+        HASH_FIND(hh, state->mediators, &(knownaddr->medid),
+                sizeof(knownaddr->medid), prevmed);
+        knownaddr->medid = provmed->mediatorid;
 
         if (prevmed) {
-            /* The mediator has changed its details somehow, withdraw any
-             * references to the old one.
-             */
-            if (push_mediator_withdraw_onto_net_buffer(cs->outgoing,
-                    prevmed) < 0) {
-                if (cs->log_allowed) {
-                    logger(LOG_INFO,
-                        "OpenLI provisioner: error pushing mediator withdrawal %s:%s onto buffer for writing to collectori %s.",
-                        prevmed->ipstr, prevmed->portstr, col->identifier);
-                }
-                ret = -1;
-                break;
-            }
+            announce_mediator_withdraw(state, prevmed);
+            HASH_DELETE(hh, state->mediators, prevmed);
+            free_openli_mediator(prevmed->details);
+            destroy_provisioner_client(state->epoll_fd, prevmed->client,
+                    identifier);
+            free(prevmed);
         }
-
-        if (push_mediator_onto_net_buffer(cs->outgoing, provmed->details) < 0) {
-            if (cs->log_allowed) {
-                logger(LOG_INFO,
-                    "OpenLI provisioner: error pushing mediator %s:%s onto buffer for writing to collector %s.",
-                    provmed->details->ipstr, provmed->details->portstr,
-                    col->identifier);
-            }
-            ret = -1;
-            break;
-        }
-
-        if (enable_epoll_write(state, col->client.commev) == -1) {
-            if (cs->log_allowed) {
-                logger(LOG_INFO,
-                    "OpenLI provisioner: cannot enable epoll write event to transmit mediator update to collector %s -- %s.",
-                    col->identifier, strerror(errno));
-            }
-            ret = -1;
-            break;
-        }
-
     }
-    if (prevmed) {
-        free(prevmed->ipstr);
-        free(prevmed->portstr);
-        free(prevmed);
+
+    if (provmed) {
+        announce_mediator(state, provmed);
     }
+
     return ret;
 }
 
-void free_all_mediators(int epollfd, prov_mediator_t **mediators) {
+static void free_all_pending(int epollfd, prov_client_t **pending) {
+
+    prov_client_t *client, *tmp;
+
+    HASH_ITER(hh, *pending, client, tmp) {
+        HASH_DELETE(hh, *pending, client);
+        destroy_provisioner_client(epollfd, client, client->identifier);
+    }
+}
+
+void free_all_mediators(int epollfd, prov_mediator_t **mediators,
+        mediator_address_t **knownmeds) {
 
     prov_mediator_t *med, *medtmp;
+    mediator_address_t *kaddr, *ktmp;
 
     HASH_ITER(hh, *mediators, med, medtmp) {
         HASH_DELETE(hh, *mediators, med);
+        destroy_provisioner_client(epollfd, med->client, med->details->ipstr);
         free_openli_mediator(med->details);
-        destroy_provisioner_client(epollfd, &(med->client), med->identifier);
-        free(med->identifier);
         free(med);
+    }
+
+    HASH_ITER(hh, *knownmeds, kaddr, ktmp) {
+        HASH_DELETE(hh, *knownmeds, kaddr);
+        if (kaddr->ipportstr) {
+            free(kaddr->ipportstr);
+        }
+        free(kaddr);
     }
 }
 
@@ -401,7 +557,7 @@ void stop_all_collectors(int epollfd, prov_collector_t **collectors) {
 
     HASH_ITER(hh, *collectors, col, coltmp) {
         HASH_DELETE(hh, *collectors, col);
-        destroy_provisioner_client(epollfd, &(col->client), col->identifier);
+        destroy_provisioner_client(epollfd, col->client, col->identifier);
         free(col->identifier);
         free(col);
     }
@@ -449,8 +605,10 @@ void clear_prov_state(provision_state_t *state) {
 
     clear_intercept_state(&(state->interceptconf));
 
+    free_all_pending(state->epoll_fd, &(state->pendingclients));
     stop_all_collectors(state->epoll_fd, &(state->collectors));
-    free_all_mediators(state->epoll_fd, &(state->mediators));
+    free_all_mediators(state->epoll_fd, &(state->mediators),
+            &(state->knownmeds));
 
     close(state->epoll_fd);
 
@@ -842,6 +1000,7 @@ static int receive_collector(provision_state_t *state, prov_epoll_ev_t *pev) {
                 }
                 cs->trusted = 1;
                 justauthed = 1;
+                add_collector_to_hashmap(state, pev->client);
                 break;
             default:
                 if (cs->log_allowed) {
@@ -919,7 +1078,7 @@ static int receive_mediator(provision_state_t *state, prov_epoll_ev_t *pev) {
                 }
 
                 if (update_mediator_details(state, msgbody, msglen,
-                            cs->ipaddr) == -1) {
+                        cs, cs->ipaddr) == -1) {
                     return -1;
                 }
                 break;
@@ -983,96 +1142,105 @@ static int transmit_socket(provision_state_t *state, prov_epoll_ev_t *pev) {
     return 1;
 }
 
-static int accept_collector(provision_state_t *state) {
+static inline int accept_client(int sock, char *identspace,
+        int spacelen) {
 
     int newfd;
     struct sockaddr_storage saddr;
     socklen_t socklen = sizeof(saddr);
     char strbuf[INET6_ADDRSTRLEN];
     char portbuf[10];
-    prov_collector_t *col;
 
-    /* TODO check for EPOLLHUP or EPOLLERR */
-
-    /* Accept, then add to list of collectors. Push all active intercepts
-     * out to the collector. */
-    newfd = accept(state->clientfd->fd, (struct sockaddr *)&saddr, &socklen);
+    newfd = accept(sock, (struct sockaddr *)&saddr, &socklen);
     if (newfd < 0) {
         return newfd;
     }
-
     fd_set_nonblock(newfd);
 
     if (getnameinfo((struct sockaddr *)&saddr, socklen, strbuf, sizeof(strbuf),
             portbuf, sizeof(portbuf), NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
         logger(LOG_INFO, "OpenLI: getnameinfo error in provisioner: %s.",
                 strerror(errno));
+        close(newfd);
+        return -1;
+    }
+
+    snprintf(identspace, spacelen, "%s-%s", strbuf, portbuf);
+    return newfd;
+}
+
+
+static int accept_collector(provision_state_t *state) {
+
+    char identbuf[INET6_ADDRSTRLEN + 11];
+    prov_client_t *colclient;
+    int newfd = -1;
+
+    /* TODO check for EPOLLHUP or EPOLLERR */
+
+    /* Accept, then add to list of collectors. Push all active intercepts
+     * out to the collector. */
+
+    if ((newfd = accept_client(state->clientfd->fd, identbuf,
+            INET6_ADDRSTRLEN + 11)) < 0) {
+        return -1;
     }
 
     /* See if this collector already exists */
-    HASH_FIND(hh, state->collectors, strbuf, strlen(strbuf), col);
+    HASH_FIND(hh, state->pendingclients, identbuf, strlen(identbuf), colclient);
 
-    if (!col) {
-        col = calloc(1, sizeof(prov_collector_t));
-        col->identifier = strdup(strbuf);
-        init_provisioner_client(&(col->client));
+    if (!colclient) {
+        colclient = calloc(1, sizeof(prov_client_t));
+        colclient->identifier = strdup(identbuf);
+        colclient->clientrole = PROV_EPOLL_COLLECTOR;
+        init_provisioner_client(colclient);
 
-        HASH_ADD_KEYPTR(hh, state->collectors, col->identifier,
-                strlen(col->identifier), col);
+        HASH_ADD_KEYPTR(hh, state->pendingclients, colclient->identifier,
+                strlen(colclient->identifier), colclient);
     }
 
-    halt_provisioner_client_idletimer(state->epoll_fd, &(col->client),
-            col->identifier);
+    halt_provisioner_client_idletimer(state->epoll_fd, colclient,
+            colclient->identifier);
 
     return accept_provisioner_client(&(state->sslconf), state->epoll_fd,
-            col->identifier, &(col->client), newfd, PROV_EPOLL_COLLECTOR,
+            colclient->identifier, colclient, newfd, PROV_EPOLL_COLLECTOR,
             PROV_EPOLL_COLLECTOR_HANDSHAKE);
 
 }
 
 static int accept_mediator(provision_state_t *state) {
 
-    int newfd;
-    struct sockaddr_storage saddr;
-    socklen_t socklen = sizeof(saddr);
-    char strbuf[INET6_ADDRSTRLEN];
-    char portbuf[10];
-    prov_mediator_t *med;
+    char identbuf[10 + INET6_ADDRSTRLEN + 1];
+    prov_client_t *medclient;
+    int newfd = -1;
 
     /* TODO check for EPOLLHUP or EPOLLERR */
 
     /* Accept, then add to list of mediators. Push all known LEAs to the
      * mediator, as well as any intercept->LEA mappings that we have.
      */
-    newfd = accept(state->mediatorfd->fd, (struct sockaddr *)&saddr, &socklen);
-    if (newfd < 0) {
-        return newfd;
-    }
-    fd_set_nonblock(newfd);
-
-    if (getnameinfo((struct sockaddr *)&saddr, socklen, strbuf, sizeof(strbuf),
-            portbuf, sizeof(portbuf), NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
-        logger(LOG_INFO, "OpenLI: getnameinfo error in provisioner: %s.",
-                strerror(errno));
-    }
-
     /* See if this mediator already exists */
-    HASH_FIND(hh, state->mediators, strbuf, strlen(strbuf), med);
-
-    if (!med) {
-        med = calloc(1, sizeof(prov_mediator_t));
-        med->identifier = strdup(strbuf);
-        init_provisioner_client(&(med->client));
-
-        HASH_ADD_KEYPTR(hh, state->mediators, med->identifier,
-                strlen(med->identifier), med);
+    if ((newfd = accept_client(state->mediatorfd->fd, identbuf,
+            INET6_ADDRSTRLEN + 11)) < 0) {
+        return -1;
     }
 
-    halt_provisioner_client_idletimer(state->epoll_fd, &(med->client),
-            med->identifier);
+    HASH_FIND(hh, state->pendingclients, identbuf, strlen(identbuf), medclient);
+
+    if (!medclient) {
+        medclient = calloc(1, sizeof(prov_client_t));
+        init_provisioner_client(medclient);
+        medclient->identifier = strdup(identbuf);
+        medclient->clientrole = PROV_EPOLL_MEDIATOR;
+        HASH_ADD_KEYPTR(hh, state->pendingclients, medclient->identifier,
+                strlen(medclient->identifier), medclient);
+    }
+
+    halt_provisioner_client_idletimer(state->epoll_fd, medclient,
+            medclient->identifier);
 
     return accept_provisioner_client(&(state->sslconf), state->epoll_fd,
-            med->identifier, &(med->client), newfd, PROV_EPOLL_MEDIATOR,
+            medclient->identifier, medclient, newfd, PROV_EPOLL_MEDIATOR,
             PROV_EPOLL_MEDIATOR_HANDSHAKE);
 
 }
@@ -1177,11 +1345,21 @@ static void remove_idle_client(provision_state_t *state, prov_epoll_ev_t *pev) {
 
     prov_sock_state_t *cs = (prov_sock_state_t *)(pev->client->state);
 
-    if (cs->clientrole == PROV_EPOLL_COLLECTOR) {
+    if (cs->parent == NULL) {
+        prov_client_t *client;
+
+        HASH_FIND(hh, state->pendingclients, cs->ipaddr, strlen(cs->ipaddr),
+                client);
+        if (client) {
+            logger(LOG_DEBUG, "OpenLI: removed pending client %s from internal list", cs->ipaddr);
+            HASH_DELETE(hh, state->pendingclients, client);
+        }
+        destroy_provisioner_client(state->epoll_fd, pev->client, cs->ipaddr);
+
+    } else if (cs->clientrole == PROV_EPOLL_COLLECTOR) {
         prov_collector_t *col;
 
-        HASH_FIND(hh, state->collectors, cs->ipaddr, strlen(cs->ipaddr), col);
-        destroy_provisioner_client(state->epoll_fd, pev->client, cs->ipaddr);
+        col = (prov_collector_t *)(cs->parent);
         if (col) {
             logger(LOG_DEBUG, "OpenLI: removed collector %s from internal list",
                     col->identifier);
@@ -1189,19 +1367,19 @@ static void remove_idle_client(provision_state_t *state, prov_epoll_ev_t *pev) {
             free(col->identifier);
             free(col);
         }
+        destroy_provisioner_client(state->epoll_fd, pev->client, cs->ipaddr);
     } else if (cs->clientrole == PROV_EPOLL_MEDIATOR) {
         prov_mediator_t *med;
 
-        HASH_FIND(hh, state->mediators, cs->ipaddr, strlen(cs->ipaddr), med);
-        destroy_provisioner_client(state->epoll_fd, pev->client, cs->ipaddr);
+        med = (prov_mediator_t *)(cs->parent);
         if (med) {
-            logger(LOG_DEBUG, "OpenLI: removed mediator %s from internal list",
-                    med->identifier);
+            logger(LOG_DEBUG, "OpenLI: removed mediator %u from internal list",
+                    med->mediatorid);
             HASH_DELETE(hh, state->mediators, med);
             free_openli_mediator(med->details);
-            free(med->identifier);
             free(med);
         }
+        destroy_provisioner_client(state->epoll_fd, pev->client, cs->ipaddr);
     }
 
 }

--- a/src/provisioner/provisioner.c
+++ b/src/provisioner/provisioner.c
@@ -450,10 +450,14 @@ static int update_mediator_details(provision_state_t *state, uint8_t *medmsg,
                 prevmed->details->portstr,
                 med->mediatorid, med->ipstr, med->portstr);
 
-        announce_mediator_withdraw(state, prevmed);
+        //announce_mediator_withdraw(state, prevmed);
         tmp = prevmed->details;
         prevmed->details = med;
         provmed = prevmed;
+
+        free(tmp->ipstr);
+        free(tmp->portstr);
+        free(tmp);
     } else {
         HASH_FIND(hh, state->pendingclients, clientname, strlen(clientname),
                 pending);
@@ -1401,7 +1405,7 @@ static void expire_unauthed(provision_state_t *state, prov_epoll_ev_t *pev) {
                     "OpenLI Provisioner: dropping unauthed mediator.");
         }
     }
-    disconnect_provisioner_client(state->epoll_fd, pev->client, cs->ipaddr);
+    destroy_provisioner_client(state->epoll_fd, pev->client, cs->ipaddr);
 
 }
 

--- a/src/provisioner/provisioner.h
+++ b/src/provisioner/provisioner.h
@@ -124,6 +124,10 @@ typedef struct prov_sock_state prov_sock_state_t;
  */
 struct prov_client {
 
+    char *identifier;
+
+    int clientrole;
+
     /** Epoll event for the main communication socket */
     prov_epoll_ev_t *commev;
 
@@ -145,6 +149,8 @@ struct prov_client {
     /** Flag to indicate whether our last connection failed for a non-SSL
      *  reason */
     uint8_t lastothererror;
+
+    UT_hash_handle hh;
 };
 
 /* Describes a collector that is being served by the provisioner */
@@ -153,7 +159,7 @@ typedef struct prov_collector {
     char *identifier;
 
     /** Common "client" state */
-    prov_client_t client;
+    prov_client_t *client;
 
     UT_hash_handle hh;
 } prov_collector_t;
@@ -161,10 +167,10 @@ typedef struct prov_collector {
 /* Describes a mediator that is being served by the provisioner */
 typedef struct prov_mediator {
 
-    /** Unique identifier for the mediator (using the IP address for now) */
-    char *identifier;
+    /** Unique identifier for the mediator */
+    uint32_t mediatorid;
     /** Common "client" state */
-    prov_client_t client;
+    prov_client_t *client;
 
     /** The IP address and port that the mediator is listening on for
      *  connections from collectors */
@@ -196,6 +202,13 @@ typedef struct prov_intercept_conf {
     pthread_mutex_t safelock;
 } prov_intercept_conf_t;
 
+typedef struct mediator_address {
+    char *ipportstr;
+    uint32_t medid;
+
+    UT_hash_handle hh;
+} mediator_address_t;
+
 /** Global state for the provisioner instance */
 typedef struct prov_state {
 
@@ -219,7 +232,11 @@ typedef struct prov_state {
     /** The file descriptor that is used for polling using epoll */
     int epoll_fd;
 
-    /** The set of mediators that we are managing */
+    prov_client_t *pendingclients;
+
+    mediator_address_t *knownmeds;
+
+    /** The set of mediators that we are managing, keyed by mediator ID */
     prov_mediator_t *mediators;
 
     /** The set of collectors that we are managing */
@@ -255,7 +272,7 @@ typedef struct prov_state {
 
 /** Socket state information for a single client */
 struct prov_sock_state {
-    /** The IP address of the client, used for identification purposes */
+    /** The IP address and port of the client, used for identification */
     char *ipaddr;
 
     /** A flag indicating whether we should log errors that occur when
@@ -267,6 +284,8 @@ struct prov_sock_state {
     net_buffer_t *incoming;
     /** Buffer for storing messages that are to be sent to the client */
     net_buffer_t *outgoing;
+
+    void *parent;
 
     /** Set to 1 if the client has authenticated, 0 otherwise */
     uint8_t trusted;
@@ -283,7 +302,8 @@ struct prov_sock_state {
  */
 int init_prov_state(provision_state_t *state, char *configfile);
 void clear_prov_state(provision_state_t *state);
-void free_all_mediators(int epollfd, prov_mediator_t **mediators);
+void free_all_mediators(int epollfd, prov_mediator_t **mediators,
+        mediator_address_t **knownmeds);
 void stop_all_collectors(int epollfd, prov_collector_t **collectors);
 int start_main_listener(provision_state_t *state);
 int start_mediator_listener(provision_state_t *state);

--- a/src/provisioner/provisioner_client.c
+++ b/src/provisioner/provisioner_client.c
@@ -161,7 +161,11 @@ void destroy_provisioner_client(int epollfd, prov_client_t *client,
 	disconnect_provisioner_client(epollfd, client, identifier);
 	halt_provisioner_client_idletimer(epollfd, client, identifier);
 
+    if (client->identifier) {
+        free(client->identifier);
+    }
 	destroy_client_state(client->state);
+    free(client);
 }
 
 /** Create fresh socket state for a newly connected client */

--- a/src/provisioner/provisioner_client.c
+++ b/src/provisioner/provisioner_client.c
@@ -131,15 +131,24 @@ static void halt_provisioner_client_mainfd(int epollfd, prov_client_t *client,
 void disconnect_provisioner_client(int epollfd, prov_client_t *client,
 		char *identifier) {
 
+	prov_sock_state_t *cs = client->state;
 	/* If we were waiting on auth, make sure to remove the timer */
 	halt_provisioner_client_authtimer(epollfd, client, identifier);
 	halt_provisioner_client_mainfd(epollfd, client, identifier);
 
-	/* Start the idle timer, so we can remove this client if it is no
-     * longer being used.
-     */
-	start_provisioner_client_idletimer(epollfd, client, identifier,
-			PROVISIONER_IDLE_TIMEOUT_SECS);
+    if (cs->clientrole == PROV_EPOLL_MEDIATOR) {
+        /* Don't expire and withdraw idle mediators -- we want the
+         * collectors to keep buffering for them in case they come back.
+         */
+        halt_provisioner_client_idletimer(epollfd, client, identifier);
+    } else {
+    	/* Start the idle timer, so we can remove this client if it is no
+         * longer being used.
+        */
+	    start_provisioner_client_idletimer(epollfd, client, identifier,
+	    		PROVISIONER_IDLE_TIMEOUT_SECS);
+    }
+
 	if (client->ssl) {
 		SSL_free(client->ssl);
 		client->ssl = NULL;
@@ -191,6 +200,7 @@ static void create_prov_socket_state(prov_client_t *client, int authtimerfd,
     cs->trusted = 0;
     cs->halted = 0;
     cs->clientrole = fdtype;
+    cs->parent = NULL;
 
     client->state = cs;
 }


### PR DESCRIPTION
Quite a variety of issues are resolved in here:
 * Fix bug where a reconnecting mediator would never receive the records that a collector had been buffering while it was gone.
 * Fix bug where a new mediator that uses the same IP + port as an old mediator would receive all intercepts intended for the old mediator, even if they have different mediator IDs.
 * Fix bug where SSL writes from collector to mediator would fail due to the forwarder adding more records to the buffer.
 * Fix bug where a provisioner disconnect would lead to the collectors dropping their connections to the mediators.
 * Fix memory leaks reported by valgrind due to IPCC encoding jobs being stuck in a queue when the collector exits.
 * Fix memory leaks caused when a provisioner reconnects and sends unchanged information about intercepts, coreservers etc. to the other components. The info is (rightly) being silently ignored by the components, but they were not always properly freeing allocated memory within the messages containing that duplicate information.
 * Fix "(null):(null)" in collector log messages that report a full buffer for a missing mediator.
 * Fix some segfaults when OOM occurs on the collector (usually due to a missing mediator). 